### PR TITLE
Lcc check

### DIFF
--- a/graspy/embed/ase.py
+++ b/graspy/embed/ase.py
@@ -44,7 +44,8 @@ class AdjacencySpectralEmbed(BaseEmbed):
     check_lcc : bool , optional (defult = True)
         Whether to check if input graph is connected. May result in non-optimal 
         results if the graph is unconnected. If True and input is unconnected,
-        a UserWarning is thrown.
+        a UserWarning is thrown. Not checking for connectedness may result in 
+        faster computatoin.
 
     Attributes
     ----------

--- a/graspy/embed/ase.py
+++ b/graspy/embed/ase.py
@@ -41,6 +41,10 @@ class AdjacencySpectralEmbed(BaseEmbed):
         Number of iterations for randomized SVD solver. Not used by 'full' or 
         'truncated'. The default is larger than the default in randomized_svd 
         to handle sparse matrices that may have large slowly decaying spectrum.
+    check_lcc : bool , optional (defult = True)
+        Whether to check if input graph is connected. May result in non-optimal 
+        results if the graph is unconnected. If True and input is unconnected,
+        a UserWarning is thrown.
 
     Attributes
     ----------
@@ -69,7 +73,7 @@ class AdjacencySpectralEmbed(BaseEmbed):
     matrix of the graph. These basis vectors (in the matrices U or V) are ordered according 
     to the amount of variance they explain in the original matrix. By selecting a subset of these
     basis vectors (through our choice of dimensionality reduction) we can find a lower dimensional 
-    space in which to represent the graph
+    space in which to represent the graph.
 
     References
     ----------

--- a/graspy/embed/ase.py
+++ b/graspy/embed/ase.py
@@ -78,12 +78,20 @@ class AdjacencySpectralEmbed(BaseEmbed):
        Journal of the American Statistical Association, Vol. 107(499), 2012
     """
 
-    def __init__(self, n_components=None, n_elbows=2, algorithm="randomized", n_iter=5):
+    def __init__(
+        self,
+        n_components=None,
+        n_elbows=2,
+        algorithm="randomized",
+        n_iter=5,
+        check_lcc=True,
+    ):
         super().__init__(
             n_components=n_components,
             n_elbows=n_elbows,
             algorithm=algorithm,
             n_iter=n_iter,
+            check_lcc=check_lcc,
         )
 
     def fit(self, graph, y=None):
@@ -101,11 +109,14 @@ class AdjacencySpectralEmbed(BaseEmbed):
         """
         A = import_graph(graph)
 
-        if not is_fully_connected(A):
-            msg = """Input graph is not fully connected. Results may not \
-            be optimal. You can compute the largest connected component by \
-            using ``graspy.utils.get_lcc``."""
-            warnings.warn(msg, UserWarning)
+        if self.check_lcc:
+            if not is_fully_connected(A):
+                msg = (
+                    "Input graph is not fully connected. Results may not"
+                    + "be optimal. You can compute the largest connected component by"
+                    + "using ``graspy.utils.get_lcc``."
+                )
+                warnings.warn(msg, UserWarning)
 
         self._reduce_dim(A)
         return self

--- a/graspy/embed/ase.py
+++ b/graspy/embed/ase.py
@@ -45,7 +45,7 @@ class AdjacencySpectralEmbed(BaseEmbed):
         Whether to check if input graph is connected. May result in non-optimal 
         results if the graph is unconnected. If True and input is unconnected,
         a UserWarning is thrown. Not checking for connectedness may result in 
-        faster computatoin.
+        faster computation.
 
     Attributes
     ----------

--- a/graspy/embed/base.py
+++ b/graspy/embed/base.py
@@ -54,11 +54,19 @@ class BaseEmbed(BaseEstimator):
     graspy.embed.selectSVD, graspy.embed.select_dimension
     """
 
-    def __init__(self, n_components=None, n_elbows=2, algorithm="randomized", n_iter=5):
+    def __init__(
+        self,
+        n_components=None,
+        n_elbows=2,
+        algorithm="randomized",
+        n_iter=5,
+        check_lcc=True,
+    ):
         self.n_components = n_components
         self.n_elbows = n_elbows
         self.algorithm = algorithm
         self.n_iter = n_iter
+        self.check_lcc = check_lcc
 
     def _reduce_dim(self, A):
         """

--- a/graspy/embed/base.py
+++ b/graspy/embed/base.py
@@ -43,6 +43,9 @@ class BaseEmbed(BaseEstimator):
         Number of iterations for randomized SVD solver. Not used by 'full' or 
         'truncated'. The default is larger than the default in randomized_svd 
         to handle sparse matrices that may have large slowly decaying spectrum.
+    check_lcc : bool , optional (defult =True)
+        Whether to check if input graph is connected. May result in non-optimal 
+        results if the graph is unconnected.
 
     Attributes
     ----------

--- a/graspy/embed/base.py
+++ b/graspy/embed/base.py
@@ -45,7 +45,8 @@ class BaseEmbed(BaseEstimator):
         to handle sparse matrices that may have large slowly decaying spectrum.
     check_lcc : bool , optional (defult =True)
         Whether to check if input graph is connected. May result in non-optimal 
-        results if the graph is unconnected.
+        results if the graph is unconnected. Not checking for connectedness may 
+        result in faster computation.
 
     Attributes
     ----------

--- a/graspy/embed/lse.py
+++ b/graspy/embed/lse.py
@@ -47,6 +47,11 @@ class LaplacianSpectralEmbed(BaseEmbed):
         'truncated'. The default is larger than the default in randomized_svd 
         to handle sparse matrices that may have large slowly decaying spectrum.
 
+    check_lcc : bool , optional (defult = True)
+        Whether to check if input graph is connected. May result in non-optimal 
+        results if the graph is unconnected. If True and input is unconnected,
+        a UserWarning is thrown.
+
     Attributes
     ----------
     latent_left_ : array, shape (n_samples, n_components)
@@ -75,7 +80,7 @@ class LaplacianSpectralEmbed(BaseEmbed):
     matrix of the graph. These basis vectors (in the matrices U or V) are ordered according 
     to the amount of variance they explain in the original matrix. By selecting a subset of these
     basis vectors (through our choice of dimensionality reduction) we can find a lower dimensional 
-    space in which to represent the graph
+    space in which to represent the graph.
 
     References
     ----------

--- a/graspy/embed/lse.py
+++ b/graspy/embed/lse.py
@@ -50,7 +50,8 @@ class LaplacianSpectralEmbed(BaseEmbed):
     check_lcc : bool , optional (defult = True)
         Whether to check if input graph is connected. May result in non-optimal 
         results if the graph is unconnected. If True and input is unconnected,
-        a UserWarning is thrown.
+        a UserWarning is thrown. Not checking for connectedness may result in 
+        faster computation.
 
     Attributes
     ----------

--- a/graspy/embed/lse.py
+++ b/graspy/embed/lse.py
@@ -91,12 +91,14 @@ class LaplacianSpectralEmbed(BaseEmbed):
         n_elbows=2,
         algorithm="randomized",
         n_iter=5,
+        check_lcc=True,
     ):
         super().__init__(
             n_components=n_components,
             n_elbows=n_elbows,
             algorithm=algorithm,
             n_iter=n_iter,
+            check_lcc=check_lcc,
         )
         self.form = form
 
@@ -115,12 +117,20 @@ class LaplacianSpectralEmbed(BaseEmbed):
 
         y : Ignored
 
-
         Returns
         -------
         self : returns an instance of self.
         """
         A = import_graph(graph)
+
+        if self.check_lcc:
+            if not is_fully_connected(A):
+                msg = (
+                    "Input graph is not fully connected. Results may not"
+                    + "be optimal. You can compute the largest connected component by"
+                    + "using ``graspy.utils.get_lcc``."
+                )
+                warnings.warn(msg, UserWarning)
 
         L_norm = to_laplace(A, form=self.form)
         self._reduce_dim(L_norm)

--- a/graspy/embed/omni.py
+++ b/graspy/embed/omni.py
@@ -132,12 +132,20 @@ class OmnibusEmbed(BaseEmbed):
     graspy.embed.select_dimension
     """
 
-    def __init__(self, n_components=None, n_elbows=2, algorithm="randomized", n_iter=5):
+    def __init__(
+        self,
+        n_components=None,
+        n_elbows=2,
+        algorithm="randomized",
+        n_iter=5,
+        check_lcc=True,
+    ):
         super().__init__(
             n_components=n_components,
             n_elbows=n_elbows,
             algorithm=algorithm,
             n_iter=n_iter,
+            check_lcc=check_lcc,
         )
 
     def fit(self, graphs, y=None):
@@ -170,11 +178,14 @@ class OmnibusEmbed(BaseEmbed):
         graphs = np.stack(graphs)
 
         # Check if Abar is connected
-        if not is_fully_connected(graphs.mean(axis=0)):
-            msg = r"""Input graphs are not fully connected. Results may not \
-            be optimal. You can compute the largest connected component by \
-            using ``graspy.utils.get_multigraph_union_lcc``."""
-            warnings.warn(msg, UserWarning)
+        if self.check_lcc:
+            if not is_fully_connected(graphs.mean(axis=0)):
+                msg = (
+                    "Input graphs are not fully connected. Results may not"
+                    + "be optimal. You can compute the largest connected component by"
+                    + "using ``graspy.utils.get_multigraph_union_lcc``."
+                )
+                warnings.warn(msg, UserWarning)
 
         # Create omni matrix
         omni_matrix = _get_omni_matrix(graphs)

--- a/graspy/embed/omni.py
+++ b/graspy/embed/omni.py
@@ -81,7 +81,7 @@ class OmnibusEmbed(BaseEmbed):
     matrices of a collection :math:`m` undirected graphs with matched vertices. 
     Then the :math:`(mn \times mn)` omnibus matrix, :math:`M`, has the subgraph where 
     :math:`M_{ij} = \frac{1}{2}(A_i + A_j)`. The omnibus matrix is then embedded
-    using adjacency spectral embedding.
+    using adjacency spectral embedding [1]_.
 
     Parameters
     ----------
@@ -107,6 +107,10 @@ class OmnibusEmbed(BaseEmbed):
         Number of iterations for randomized SVD solver. Not used by 'full' or 
         'truncated'. The default is larger than the default in randomized_svd 
         to handle sparse matrices that may have large slowly decaying spectrum.
+    check_lcc : bool , optional (defult = True)
+        Whether to check if the average of all input graphs are connected. May result
+        in non-optimal results if the average graph is unconnected. If True and average
+        graph is unconnected, a UserWarning is thrown. 
 
     Attributes
     ----------
@@ -130,6 +134,13 @@ class OmnibusEmbed(BaseEmbed):
     --------
     graspy.embed.selectSVD
     graspy.embed.select_dimension
+
+    References
+    ----------
+    .. [1] Levin, K., Athreya, A., Tang, M., Lyzinski, V., & Priebe, C. E. (2017, 
+       November).A central limit theorem for an omnibus embedding of multiple random 
+       dot product graphs. In Data Mining Workshops (ICDMW), 2017 IEEE International 
+       Conference on (pp. 964-967). IEEE.
     """
 
     def __init__(

--- a/graspy/inference/semipar.py
+++ b/graspy/inference/semipar.py
@@ -155,9 +155,9 @@ class SemiparametricTest(BaseInference):
                 n_components=self.n_components, check_lcc=check_lcc
             ).fit_transform(A2)
         elif self.embedding == "omnibus":
-            X_hat_compound = OmnibusEmbed(n_components=self.n_components).fit_transform(
-                (A1, A2)
-            )
+            X_hat_compound = OmnibusEmbed(
+                n_components=self.n_components, check_lcc=check_lcc
+            ).fit_transform((A1, A2))
             X1_hat = X_hat_compound[: A1.shape[0], :]
             X2_hat = X_hat_compound[A2.shape[0] :, :]
         return (X1_hat, X2_hat)

--- a/graspy/inference/semipar.py
+++ b/graspy/inference/semipar.py
@@ -149,10 +149,10 @@ class SemiparametricTest(BaseInference):
     def _embed(self, A1, A2, check_lcc=True):
         if self.embedding == "ase":
             X1_hat = AdjacencySpectralEmbed(
-                n_components=self.n_components
+                n_components=self.n_components, check_lcc=check_lcc
             ).fit_transform(A1)
             X2_hat = AdjacencySpectralEmbed(
-                n_components=self.n_components
+                n_components=self.n_components, check_lcc=check_lcc
             ).fit_transform(A2)
         elif self.embedding == "omnibus":
             X_hat_compound = OmnibusEmbed(n_components=self.n_components).fit_transform(

--- a/graspy/inference/semipar.py
+++ b/graspy/inference/semipar.py
@@ -119,7 +119,9 @@ class SemiparametricTest(BaseInference):
         for i in range(self.n_bootstraps):
             A1_simulated = rdpg(X_hat, rescale=self.rescale, loops=self.loops)
             A2_simulated = rdpg(X_hat, rescale=self.rescale, loops=self.loops)
-            X1_hat_simulated, X2_hat_simulated = self._embed(A1_simulated, A2_simulated)
+            X1_hat_simulated, X2_hat_simulated = self._embed(
+                A1_simulated, A2_simulated, check_lcc=False
+            )
             t_bootstrap[i] = self._difference_norm(X1_hat_simulated, X2_hat_simulated)
         return t_bootstrap
 
@@ -144,7 +146,7 @@ class SemiparametricTest(BaseInference):
             # in the omni case we don't need to align
             return np.linalg.norm(X1 - X2)
 
-    def _embed(self, A1, A2):
+    def _embed(self, A1, A2, check_lcc=True):
         if self.embedding == "ase":
             X1_hat = AdjacencySpectralEmbed(
                 n_components=self.n_components

--- a/tests/test_spectral_embed.py
+++ b/tests/test_spectral_embed.py
@@ -123,11 +123,11 @@ class TestLaplacianSpectralEmbed(unittest.TestCase):
         f = np.array([[1, 2], [2, 1]])
         lse = LaplacianSpectralEmbed(form="I-DAD")
 
-    def test_unconnected_error(self):
+    def test_unconnected_warning(self):
         n = [50, 50]
         p = [[1, 0], [0, 1]]
         A = sbm(n, p)
-        with self.assertRaises(ValueError):
+        with self.assertWarns(UserWarning):
             lse = LaplacianSpectralEmbed()
             lse.fit(A)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -91,11 +91,6 @@ class TestChecks(unittest.TestCase):
         self.assertTrue(gus.is_unweighted(B))
         self.assertFalse(gus.is_unweighted(self.A))
 
-    def test_unconnected_laplacian(self):
-        A = np.array([[0, 1, 0], [1, 0, 0], [0, 0, 0]])
-        with self.assertRaises(ValueError):
-            gus.to_laplace(A)
-
     def test_is_fully_connected(self):
         # graph where node at index [3] only connects to self
         A = np.array([[1, 0, 1, 0], [0, 1, 1, 0], [1, 1, 0, 0], [0, 0, 0, 1]])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/neurodata/graspy/blob/master/CONTRIBUTING.md#pull-request-checklist
-->


#### What does this implement/fix? Explain your changes.
- Add `check_lcc` for all embedding methods. 
  - default is True
- `to_laplace` changed so that it works on graph with unconnected nodes. 
  - `to_laplace` no longer checks if input is unconnected as current implementation no longer cares about unconnectedness.
  - lcc checking is now done in `LaplacianSpectralEmbed`.
- Semipar is changed to only check lcc for the input graphs, but not for when computing the null via bootstrap. I chose not to put `check_lcc` arg for semipar. Assume that we want to know if the input pair of graphs are unconnected.
- Updated tests accordingly.