### PR TITLE
Import Edgelist function

### DIFF
--- a/docs/reference/utils.rst
+++ b/docs/reference/utils.rst
@@ -15,6 +15,8 @@ Helper Functions
 
 .. autofunction:: import_graph
 
+.. autofunction:: import_edgelist
+
 .. autofunction:: symmetrize
 
 .. autofunction:: remove_loops

--- a/graspy/utils/utils.py
+++ b/graspy/utils/utils.py
@@ -61,7 +61,7 @@ def import_edgelist(
 
     Parameters
     ----------
-    path : str
+    path : str, Path object
         Path to a file or directory. 
 
     delimiter : str, optional
@@ -82,9 +82,19 @@ def import_edgelist(
     graph : array-like, shape (n_vertices, n_vertices)
         Adjacency matrix of the graph created from edgelist.
     """
-    p = Path(path)
+    if isinstance(path, str):
+        p = Path(path)
+    elif isinstance(path, Path):
+        p = path
+    else:
+        raise TypeError(
+            "path variable must be either a string or Pathlib object, not {}.".format(
+                type(path)
+            )
+        )
+
     if p.is_dir():
-        files = p.glob("*." + extension)
+        files = sorted(p.glob("*." + extension))
         graphs = [nx.read_weighted_edgelist(G, nodetype=nodetype) for G in files]
 
         # doing this to avoid counting number of elemnts in iterator
@@ -94,12 +104,12 @@ def import_edgelist(
         vertices = reduce(np.union1d, [G.nodes for G in graphs])
         out = [nx.to_numpy_array(G, nodelist=vertices, dtype=np.float) for G in graphs]
     elif p.is_file():
-        G = nx.read_weighted_edgelist(path, nodetype=int, delimiter=delimiter)
-        vertices = np.sort(np.array(G.nodes))
+        G = nx.read_weighted_edgelist(path, nodetype=nodetype, delimiter=delimiter)
 
+        vertices = np.sort(np.array(G.nodes))
         out = import_graph(G)
     else:
-        raise ValueError("Invalid input")
+        raise ValueError("No graphs founds to import.")
 
     if return_vertices:
         return out, vertices

--- a/graspy/utils/utils.py
+++ b/graspy/utils/utils.py
@@ -82,16 +82,7 @@ def import_edgelist(
     graph : array-like, shape (n_vertices, n_vertices)
         Adjacency matrix of the graph created from edgelist.
     """
-    if isinstance(path, str):
-        p = Path(path)
-    elif isinstance(path, Path):
-        p = path
-    else:
-        raise TypeError(
-            "path variable must be either a string or Pathlib object, not {}.".format(
-                type(path)
-            )
-        )
+    p = Path(path)
 
     if p.is_dir():
         files = sorted(p.glob("*." + extension))

--- a/graspy/utils/utils.py
+++ b/graspy/utils/utils.py
@@ -55,33 +55,40 @@ def import_graph(graph):
 
 
 def import_edgelist(
-    path, delimiter=None, nodetype=int, extension="edgelist", return_vertices=False
+    path, extension="edgelist", delimiter=None, nodetype=int, return_vertices=False
 ):
     """
-    Function for reading an edgelist and returning a numpy array.
-    The order of nodes are sorted by node values.
+    Function for reading a single or multiple edgelists. When importing multiple 
+    edgelists, the union of vertices from all graphs is computed so that each output
+    graph have matched vertex set. The order of nodes are sorted by node values.
 
     Parameters
     ----------
-    path : str, iterable
+    path : str, Path object, or iterable
+        If ``path`` is a directory, then the importing order will be sorted in 
+        alphabetical order.
+
+    extension : str, optional
+        If ``path`` is a directory, then the function will convert all files
+        with matching extension. 
 
     delimiter : str, optional
         Delimiter of edgelist. If None, whitespace.
 
     nodetype : int (default), float, str, Python type, optional
-       Convert node data from strings to specified type
-
-    extension : str, optional
-        If ``path`` is a directory, then the function will convert all files
-        with matching extension. 
+       Convert node data from strings to specified type.
 
     return_vertices : bool, default=False, optional
         Returns the union of all ind
 
     Returns
     -------
-    graph : array-like, shape (n_vertices, n_vertices)
-        Adjacency matrix of the graph created from edgelist.
+    graph : list of array-like, or array-like, shape (n_vertices, n_vertices)
+        If ``path`` is a directory, a list of arrays is returned. If ``path`` is a file,
+        an array is returned.
+
+    vertices : array-like, shape (n_vertices, )
+        An array of all vertices that were included in the graphs that are returned.
     """
     # p = Path(path)
     if not isinstance(path, (str, Path, Iterable)):

--- a/graspy/utils/utils.py
+++ b/graspy/utils/utils.py
@@ -61,7 +61,7 @@ def import_edgelist(
 
     Parameters
     ----------
-    path : str
+    path : str, iterable
 
     delimiter : str, optional
         Delimiter of edgelist. If None, whitespace.

--- a/graspy/utils/utils.py
+++ b/graspy/utils/utils.py
@@ -72,8 +72,8 @@ def import_edgelist(
         If ``path`` is a directory, then the function will convert all files
         with matching extension. 
 
-    delimiter : str, optional
-        Delimiter of edgelist. If None, whitespace.
+    delimiter : str or None, default=None, optional
+        Delimiter of edgelist. If None, the delimiter is whitespace.
 
     nodetype : int (default), float, str, Python type, optional
        Convert node data from strings to specified type.
@@ -83,12 +83,13 @@ def import_edgelist(
 
     Returns
     -------
-    graph : list of array-like, or array-like, shape (n_vertices, n_vertices)
+    out : list of array-like, or array-like, shape (n_vertices, n_vertices)
         If ``path`` is a directory, a list of arrays is returned. If ``path`` is a file,
         an array is returned.
 
     vertices : array-like, shape (n_vertices, )
-        An array of all vertices that were included in the graphs that are returned.
+        If ``return_vertices`` == True, then returns an array of all vertices that were 
+        included in the output graphs. 
     """
     # p = Path(path)
     if not isinstance(path, (str, Path, Iterable)):

--- a/graspy/utils/utils.py
+++ b/graspy/utils/utils.py
@@ -61,8 +61,7 @@ def import_edgelist(
 
     Parameters
     ----------
-    path : str, Path object
-        Path to a file or directory. 
+    path : str
 
     delimiter : str, optional
         Delimiter of edgelist. If None, whitespace.
@@ -82,8 +81,11 @@ def import_edgelist(
     graph : array-like, shape (n_vertices, n_vertices)
         Adjacency matrix of the graph created from edgelist.
     """
-    p = Path(path)
+    # p = Path(path)
+    if not isinstance(path, str):
+        raise TypeError("path must be a string, not {}".format(type(path)))
 
+    p = Path(path)
     if p.is_dir():
         files = sorted(p.glob("*." + extension))
         graphs = [nx.read_weighted_edgelist(G, nodetype=nodetype) for G in files]

--- a/graspy/utils/utils.py
+++ b/graspy/utils/utils.py
@@ -84,12 +84,12 @@ def import_edgelist(
         Adjacency matrix of the graph created from edgelist.
     """
     # p = Path(path)
-    if not isinstance(path, (str, Iterable)):
+    if not isinstance(path, (str, Path, Iterable)):
         msg = "path must be a string or Iterable, not {}".format(type(path))
         raise TypeError(msg)
 
     # get a list of files to import
-    if isinstance(path, str):
+    if isinstance(path, (str, Path)):
         p = Path(path)
         if p.is_dir():
             files = sorted(p.glob("*" + extension))
@@ -100,7 +100,6 @@ def import_edgelist(
     else:  # path is an iterable
         files = [Path(f) for f in path]
 
-    # Do this to potentially avoid dealing with generators
     if len(files) == 0:
         msg = "No files found with '{}' extension found.".format(extension)
         raise ValueError(msg)

--- a/graspy/utils/utils.py
+++ b/graspy/utils/utils.py
@@ -52,7 +52,9 @@ def import_graph(graph):
     return out
 
 
-def import_edgelist(path, delimiter=None, nodetype=int, extension="edgelist"):
+def import_edgelist(
+    path, delimiter=None, nodetype=int, extension="edgelist", return_vertices=False
+):
     """
     Function for reading an edgelist and returning a numpy array.
     The order of nodes are sorted by node values.
@@ -72,6 +74,9 @@ def import_edgelist(path, delimiter=None, nodetype=int, extension="edgelist"):
         If ``path`` is a directory, then the function will convert all files
         with matching extension. 
 
+    return_vertices : bool, default=False, optional
+        Returns the union of all ind
+
     Returns
     -------
     graph : array-like, shape (n_vertices, n_vertices)
@@ -90,11 +95,16 @@ def import_edgelist(path, delimiter=None, nodetype=int, extension="edgelist"):
         out = [nx.to_numpy_array(G, nodelist=vertices, dtype=np.float) for G in graphs]
     elif p.is_file():
         G = nx.read_weighted_edgelist(path, nodetype=int, delimiter=delimiter)
+        vertices = np.sort(np.array(G.nodes))
+
         out = import_graph(G)
     else:
         raise ValueError("Invalid input")
 
-    return out
+    if return_vertices:
+        return out, vertices
+    else:
+        return out
 
 
 def is_symmetric(X):

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,6 +3,7 @@ addopts = --cov=graspy
 
 filterwarnings = 
 # Matrix PendingDeprecationWarning.
+    ignore:Using or importing the ABCs from 'collections'
     ignore:the matrix subclass is not
     ignore:Using a non-tuple
     ignore:Input graph is not fully connected.

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -44,7 +44,6 @@ class TestImportGraph:
 class TestImportEdgelist:
     @pytest.fixture(autouse=True)
     def setup_class(self, tmp_path):
-        self.tmp_path = tmp_path
 
         n = 10
         p = 0.5
@@ -59,11 +58,12 @@ class TestImportEdgelist:
         G_A = nx.from_numpy_array(self.A)
         G_B = nx.from_numpy_array(self.B)
 
-        self.A_path = tmp_path / "A_unweighted.edgelist"
-        self.B_path = tmp_path / "B.edgelist"
+        self.A_path = str(tmp_path / "A_unweighted.edgelist")
+        self.B_path = str(tmp_path / "B.edgelist")
+        self.root = str(tmp_path)
 
-        nx.write_edgelist(G_A, str(self.A_path), data=False)
-        nx.write_weighted_edgelist(G_B, str(self.B_path))
+        nx.write_edgelist(G_A, self.A_path, data=False)
+        nx.write_weighted_edgelist(G_B, self.B_path)
 
     def test_in(self):
         A_from_edgelist = gs.utils.import_edgelist(self.A_path)
@@ -73,15 +73,7 @@ class TestImportEdgelist:
         assert np.allclose(B_from_edgelist, self.B)
 
     def test_multiple_in(self):
-        A_parent = self.A_path.parent
-        B_parent = self.B_path.parent
-
-        graphs = gs.utils.import_edgelist(A_parent)
-        assert len(graphs) == 2
-        assert np.allclose(graphs[0], self.A)
-        assert np.allclose(graphs[1], self.B)
-
-        graphs = gs.utils.import_edgelist(B_parent)
+        graphs = gs.utils.import_edgelist(self.root)
         assert len(graphs) == 2
         assert np.allclose(graphs[0], self.A)
         assert np.allclose(graphs[1], self.B)
@@ -103,7 +95,6 @@ class TestImportEdgelist:
         assert np.allclose(expected_vertices, B_vertices)
 
     def test_no_graphs_found(self):
-        path = str(self.tmp_path / "invalid_edgelist.edgelist")
-
+        path = str(self.root + "invalid_edgelist.edgelist")
         with pytest.raises(ValueError):
             gs.utils.import_edgelist(path)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -59,8 +59,8 @@ class TestImportEdgelist:
         self.A_path = tmp_path / "A_unweighted.edgelist"
         self.B_path = tmp_path / "B.edgelist"
 
-        nx.write_edgelist(G_A, self.A_path, data=False)
-        nx.write_weighted_edgelist(G_B, self.B_path)
+        nx.write_edgelist(G_A, str(self.A_path), data=False)
+        nx.write_weighted_edgelist(G_B, str(elf.B_path))
 
     def test_in(self):
         A_from_edgelist = gs.utils.import_edgelist(self.A_path)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,4 +1,5 @@
 import sys
+from pathlib import Path
 
 import networkx as nx
 import numpy as np
@@ -68,6 +69,13 @@ class TestImportEdgelist:
     def test_in(self):
         A_from_edgelist = gs.utils.import_edgelist(self.A_path)
         B_from_edgelist = gs.utils.import_edgelist(self.B_path)
+
+        assert np.allclose(A_from_edgelist, self.A)
+        assert np.allclose(B_from_edgelist, self.B)
+
+    def test_in_Path_obj(self):
+        A_from_edgelist = gs.utils.import_edgelist(Path(self.A_path))
+        B_from_edgelist = gs.utils.import_edgelist(Path(self.B_path))
 
         assert np.allclose(A_from_edgelist, self.A)
         assert np.allclose(B_from_edgelist, self.B)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,3 +1,6 @@
+import sys
+
+
 import pytest
 import graspy as gs
 import numpy as np
@@ -93,14 +96,14 @@ class TestImportEdgelist:
     def test_vertices(self):
         expected_vertices = np.arange(0, 10)
 
-        _, A_vertices = gs.utils.import_edgelist(self.A_path, return_vertices=True)
-        _, B_vertices = gs.utils.import_edgelist(self.B_path, return_vertices=True)
+        _, A_vertices = gs.utils.import_edgelist(str(self.A_path), return_vertices=True)
+        _, B_vertices = gs.utils.import_edgelist(str(self.B_path), return_vertices=True)
 
         assert np.allclose(expected_vertices, A_vertices)
         assert np.allclose(expected_vertices, B_vertices)
 
     def test_no_graphs_found(self):
-        path = self.tmp_path / "invalid_edgelist.edgelist"
+        path = str(self.tmp_path / "invalid_edgelist.edgelist")
 
         with pytest.raises(ValueError):
             gs.utils.import_edgelist(path)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -60,7 +60,7 @@ class TestImportEdgelist:
         self.B_path = tmp_path / "B.edgelist"
 
         nx.write_edgelist(G_A, str(self.A_path), data=False)
-        nx.write_weighted_edgelist(G_B, str(elf.B_path))
+        nx.write_weighted_edgelist(G_B, str(self.B_path))
 
     def test_in(self):
         A_from_edgelist = gs.utils.import_edgelist(self.A_path)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/neurodata/graspy/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
Closes #100 

#### What does this implement/fix? Explain your changes.
Added function for importing from edgelists. Allows for a single file import or multiple file imports. Since edgelists are sparse, some nodes may get lost if they are completely unconnected. Thus, need to take into account possible differences in nodes in different edgelists by taking the union of all vertices.
