### PR TITLE
Improve visibility of the contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,5 +63,12 @@ python3 setup.py install
 # Tutorials
 Please visit the [tutorial section](https://graspy.neurodata.io/tutorial.html) in the official website
 
+# Contributing to GraSPy
+We welcome contributions from anyone. Please see our [contribution guidelines](https://github.com/neurodata/graspy/blob/master/CONTRIBUTING.md) before making a pull request. Our 
+[issues](https://github.com/neurodata/graspy/issues) page is full of places we could use help! 
+If you have an idea for an improvement not listed there, please 
+[make an issue](https://github.com/neurodata/graspy/issues/new) first so you can discuss with the 
+developers. 
+
 ## License
 This project is covered under the [Apache 2.0 License](https://github.com/neurodata/graspy/blob/master/LICENSE).


### PR DESCRIPTION
Add `CONTRIBUTING.md` as a link on the readme. Since we have more and more people contributing, I'm finding that few people have seen the `CONTRIBUTING.md` file.