### PR TITLE
Improve documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,6 +45,7 @@ extensions = [
     "sphinx.ext.githubpages",
     "sphinxcontrib.rawfiles",
     "nbsphinx",
+    "sphinx.ext.intersphinx",
 ]
 
 # -- sphinxcontrib.rawfiles

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -2,7 +2,7 @@
 Tutorial
 ********
 
-.. _models_tutorial:
+.. _models_tutorials:
 
 Models
 ======
@@ -12,8 +12,11 @@ stochastic block model (SBM), degree-corrected SBM, and random dot product graph
 .. toctree::
    :maxdepth: 1
    
+   .. _models_tutorial:
    tutorials/models/models
-   
+
+.. _simulations_tutorials:
+
 Simulations
 ===========
 The following tutorials demonstrate how to easily sample random graphs from graph models such as the Erdos-Renyi model, 
@@ -26,6 +29,8 @@ stochastic block model, and random dot product graph (RDPG).
    tutorials/simulations/sbm
    tutorials/simulations/rdpg
 
+.. _embed_tutorials:
+
 Embedding
 =========
 Inference on random graphs depends on low-dimensional Euclidean representation of the vertices of graphs, known as *graph embeddings*, typically given by spectral decompositions of adjacency or Laplacian matrices. Below are tutorials for computing graph embeddings of single graph and multiple graphs.
@@ -36,6 +41,8 @@ Inference on random graphs depends on low-dimensional Euclidean representation o
    tutorials/embedding/AdjacencySpectralEmbed
    tutorials/embedding/Omnibus
    
+.. _inference_tutorials: 
+
 Inference
 ===========================
 Statistical testing on graphs requires specialized methodology in order to account 
@@ -47,6 +54,8 @@ are tutorials for robust statistical hypothesis testing on multiple graphs.
 
    tutorials/inference/latent_position_test
    tutorials/inference/latent_distribution_test
+
+.. _plot_tutorials: 
 
 Plotting
 ========

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -13,6 +13,7 @@ stochastic block model (SBM), degree-corrected SBM, and random dot product graph
    :maxdepth: 1
    
    .. _models_tutorial:
+   
    tutorials/models/models
 
 .. _simulations_tutorials:

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -11,9 +11,7 @@ stochastic block model (SBM), degree-corrected SBM, and random dot product graph
 
 .. toctree::
    :maxdepth: 1
-   
-   .. _models_tutorial:
-   
+      
    tutorials/models/models
 
 .. _simulations_tutorials:

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -2,6 +2,8 @@
 Tutorial
 ********
 
+.. _models_tutorial
+
 Models
 ======
 This tutorial presents several random graph models: the Erdos-Renyi (ER) model, degree-corrected ER model,

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -2,7 +2,7 @@
 Tutorial
 ********
 
-.. _models_tutorial
+.. _models_tutorial:
 
 Models
 ======

--- a/graspy/cluster/gclust.py
+++ b/graspy/cluster/gclust.py
@@ -34,13 +34,13 @@ class GaussianCluster(BaseCluster):
     ----------
     min_components : int, default=2. 
         The minimum number of mixture components to consider (unless
-        max_components=None, in which case this is the maximum number of
-        components to consider). If max_componens is not None, min_components
-        must be less than or equal to max_components.
+        ``max_components=None``, in which case this is the maximum number of
+        components to consider). If ``max_componens`` is not None, ``min_components``
+        must be less than or equal to ``max_components``.
 
     max_components : int or None, default=None.
         The maximum number of mixture components to consider. Must be greater 
-        than or equal to min_components.
+        than or equal to ``min_components``.
 
     covariance_type : {'full' (default), 'tied', 'diag', 'spherical'}, optional
         String or list/array describing the type of covariance parameters to use.
@@ -60,7 +60,7 @@ class GaussianCluster(BaseCluster):
             'spherical', 'tied', 'diag', and/or 'spherical'.
     
     random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
+        If int, ``random_state`` is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
         by ``np.random``.
@@ -72,7 +72,7 @@ class GaussianCluster(BaseCluster):
     covariance_type_ : str
         Optimal covariance type based on BIC.
     model_ : GaussianMixture object
-        Fitted GaussianMixture object fitted with optimal numeber of components 
+        Fitted GaussianMixture object fitted with optimal number of components 
         and optimal covariance structure.
     bic_ : pandas.DataFrame
         A pandas DataFrame of BIC values computed for all possible number of clusters
@@ -80,8 +80,8 @@ class GaussianCluster(BaseCluster):
         structures given by covariance_type.
     ari_ : pandas.DataFrame
         Only computed when y is given. Pandas Dataframe containing ARI values computed
-        for all possible number of clusters given by range(min_components,
-        max_components) and all covariance structures given by covariance_type.
+        for all possible number of clusters given by ``r``ange(min_components,
+        max_components)`` and all covariance structures given by covariance_type.
     """
 
     def __init__(

--- a/graspy/cluster/kclust.py
+++ b/graspy/cluster/kclust.py
@@ -24,7 +24,7 @@ class KMeansCluster(BaseCluster):
     KMeans Cluster.
 
     It computes all possible models from one component to 
-    max_clusters. The best model is given by the lowest silhouette score.
+    ``max_clusters``. The best model is given by the lowest silhouette score.
 
     Parameters
     ----------
@@ -32,7 +32,7 @@ class KMeansCluster(BaseCluster):
         The maximum number of mixture components to consider.
     
     random_state : int, RandomState instance or None, optional (default=None)
-        If int, random_state is the seed used by the random number generator;
+        If int, ``random_state`` is the seed used by the random number generator;
         If RandomState instance, random_state is the random number generator;
         If None, the random number generator is the RandomState instance used
         by `np.random`.
@@ -48,11 +48,11 @@ class KMeansCluster(BaseCluster):
 
     silhouette_ : list
         List of silhouette scores computed for all possible number 
-        of clusters given by range(2, max_clusters).
+        of clusters given by ``range(2, max_clusters)``.
 
     ari_ : list
         Only computed when y is given. List of ARI values computed for 
-        all possible number of clusters given by range(2, max_clusters).
+        all possible number of clusters given by ``range(2, max_clusters)``.
     """
 
     def __init__(self, max_clusters=2, random_state=None):
@@ -78,7 +78,7 @@ class KMeansCluster(BaseCluster):
             corresponds to a single data point.
         
         y : array-like, shape (n_samples,), optional (default=None)
-            List of labels for X if available. Used to compute ARI scores.
+            List of labels for `X` if available. Used to compute ARI scores.
 
         Returns
         -------

--- a/graspy/datasets/base.py
+++ b/graspy/datasets/base.py
@@ -23,7 +23,7 @@ def load_drosophila_left(return_labels=False):
         graph : np.ndarray
             Adjacency matrix of the connectome
         labels : np.ndarray
-            Only returned if `return_labels` is true. Array of
+            Only returned if ``return_labels`` is true. Array of
             string labels for each cell (vertex)
 
     References

--- a/graspy/embed/ase.py
+++ b/graspy/embed/ase.py
@@ -34,9 +34,11 @@ class AdjacencySpectralEmbed(BaseEmbed):
         n_components must be <= min(X.shape). Otherwise, n_components must be
         < min(X.shape). If None, then optimal dimensions will be chosen by
         :func:`~graspy.embed.select_dimension` using ``n_elbows`` argument.
+
     n_elbows : int, optional, default: 2
         If ``n_components=None``, then compute the optimal embedding dimension using
         :func:`~graspy.embed.select_dimension`. Otherwise, ignored.
+
     algorithm : {'randomized' (default), 'full', 'truncated'}, optional
         SVD solver to use:
 
@@ -47,10 +49,12 @@ class AdjacencySpectralEmbed(BaseEmbed):
             Computes full svd using :func:`scipy.linalg.svd`
         - 'truncated'
             Computes truncated svd using :func:`scipy.sparse.linalg.svds`
+
     n_iter : int, optional (default = 5)
         Number of iterations for randomized SVD solver. Not used by 'full' or 
         'truncated'. The default is larger than the default in randomized_svd 
         to handle sparse matrices that may have large slowly decaying spectrum.
+        
     check_lcc : bool , optional (defult = True)
         Whether to check if input graph is connected. May result in non-optimal 
         results if the graph is unconnected. If True and input is unconnected,

--- a/graspy/embed/ase.py
+++ b/graspy/embed/ase.py
@@ -46,7 +46,7 @@ class AdjacencySpectralEmbed(BaseEmbed):
         - 'full'
             Computes full svd using :func:`scipy.linalg.svd`
         - 'truncated'
-            Computes truncated svd using :func:`scipy.sparse.linalg.svd`
+            Computes truncated svd using :func:`scipy.sparse.linalg.svds`
     n_iter : int, optional (default = 5)
         Number of iterations for randomized SVD solver. Not used by 'full' or 
         'truncated'. The default is larger than the default in randomized_svd 

--- a/graspy/embed/ase.py
+++ b/graspy/embed/ase.py
@@ -25,7 +25,7 @@ class AdjacencySpectralEmbed(BaseEmbed):
     The adjacency spectral embedding (ASE) is a k-dimensional Euclidean representation 
     of the graph based on its adjacency matrix :ref:`[1]`. It relies on an SVD to reduce
     the dimensionality to the specified k, or if k is unspecified, can find a number of 
-    dimensions automatically (see graspy.embed.selectSVD).
+    dimensions automatically (see :class:`~graspy.embed.selectSVD`).
 
     Parameters
     ----------
@@ -33,7 +33,7 @@ class AdjacencySpectralEmbed(BaseEmbed):
         Desired dimensionality of output data. If "full", 
         n_components must be <= min(X.shape). Otherwise, n_components must be
         < min(X.shape). If None, then optimal dimensions will be chosen by
-        ``select_dimension`` using ``n_elbows`` argument.
+        :func:`~graspy.embed.select_dimension` using ``n_elbows`` argument.
     n_elbows : int, optional, default: 2
         If ``n_components=None``, then compute the optimal embedding dimension using
         :func:`~graspy.embed.select_dimension`. Otherwise, ignored.

--- a/graspy/embed/ase.py
+++ b/graspy/embed/ase.py
@@ -42,7 +42,7 @@ class AdjacencySpectralEmbed(BaseEmbed):
 
         - 'randomized'
             Computes randomized svd using 
-            :meth:`sklearn.utils.extmath.randomized_svd`
+            :func:`sklearn.utils.extmath.randomized_svd`
         - 'full'
             Computes full svd using ``scipy.linalg.svd``
         - 'truncated'

--- a/graspy/embed/ase.py
+++ b/graspy/embed/ase.py
@@ -35,8 +35,8 @@ class AdjacencySpectralEmbed(BaseEmbed):
         < min(X.shape). If None, then optimal dimensions will be chosen by
         ``select_dimension`` using ``n_elbows`` argument.
     n_elbows : int, optional, default: 2
-        If `n_components=None`, then compute the optimal embedding dimension using
-        `select_dimension`. Otherwise, ignored.
+        If ``n_components=None``, then compute the optimal embedding dimension using
+        :func:`~graspy.embed.select_dimension`. Otherwise, ignored.
     algorithm : {'randomized' (default), 'full', 'truncated'}, optional
         SVD solver to use:
 
@@ -44,9 +44,9 @@ class AdjacencySpectralEmbed(BaseEmbed):
             Computes randomized svd using 
             :func:`sklearn.utils.extmath.randomized_svd`
         - 'full'
-            Computes full svd using ``scipy.linalg.svd``
+            Computes full svd using :func:`scipy.linalg.svd`
         - 'truncated'
-            Computes truncated svd using ``scipy.sparse.linalg.svd``
+            Computes truncated svd using :func:`scipy.sparse.linalg.svd`
     n_iter : int, optional (default = 5)
         Number of iterations for randomized SVD solver. Not used by 'full' or 
         'truncated'. The default is larger than the default in randomized_svd 

--- a/graspy/embed/ase.py
+++ b/graspy/embed/ase.py
@@ -23,7 +23,7 @@ class AdjacencySpectralEmbed(BaseEmbed):
     Class for computing the adjacency spectral embedding of a graph 
     
     The adjacency spectral embedding (ASE) is a k-dimensional Euclidean representation 
-    of the graph based on its adjacency matrix :ref:`[1]`. It relies on an SVD to reduce
+    of the graph based on its adjacency matrix [#1]_. It relies on an SVD to reduce
     the dimensionality to the specified k, or if k is unspecified, can find a number of 
     dimensions automatically (see :class:`~graspy.embed.selectSVD`).
 
@@ -86,7 +86,7 @@ class AdjacencySpectralEmbed(BaseEmbed):
 
     References
     ----------
-    .. _[1] Sussman, D.L., Tang, M., Fishkind, D.E., Priebe, C.E.  "A
+    .. [#1] Sussman, D.L., Tang, M., Fishkind, D.E., Priebe, C.E.  "A
        Consistent Adjacency Spectral Embedding for Stochastic Blockmodel Graphs,"
        Journal of the American Statistical Association, Vol. 107(499), 2012
     """

--- a/graspy/embed/ase.py
+++ b/graspy/embed/ase.py
@@ -27,6 +27,8 @@ class AdjacencySpectralEmbed(BaseEmbed):
     the dimensionality to the specified k, or if k is unspecified, can find a number of 
     dimensions automatically (see :class:`~graspy.embed.selectSVD`).
 
+    Read more in the :ref:`tutorials <embed_tutorials>`
+
     Parameters
     ----------
     n_components : int or None, default = None

--- a/graspy/embed/ase.py
+++ b/graspy/embed/ase.py
@@ -23,7 +23,7 @@ class AdjacencySpectralEmbed(BaseEmbed):
     Class for computing the adjacency spectral embedding of a graph 
     
     The adjacency spectral embedding (ASE) is a k-dimensional Euclidean representation 
-    of the graph based on its adjacency matrix [#1]_. It relies on an SVD to reduce
+    of the graph based on its adjacency matrix [1]_. It relies on an SVD to reduce
     the dimensionality to the specified k, or if k is unspecified, can find a number of 
     dimensions automatically (see :class:`~graspy.embed.selectSVD`).
 
@@ -54,7 +54,7 @@ class AdjacencySpectralEmbed(BaseEmbed):
         Number of iterations for randomized SVD solver. Not used by 'full' or 
         'truncated'. The default is larger than the default in randomized_svd 
         to handle sparse matrices that may have large slowly decaying spectrum.
-        
+
     check_lcc : bool , optional (defult = True)
         Whether to check if input graph is connected. May result in non-optimal 
         results if the graph is unconnected. If True and input is unconnected,
@@ -90,7 +90,7 @@ class AdjacencySpectralEmbed(BaseEmbed):
 
     References
     ----------
-    .. [#1] Sussman, D.L., Tang, M., Fishkind, D.E., Priebe, C.E.  "A
+    .. [1] Sussman, D.L., Tang, M., Fishkind, D.E., Priebe, C.E.  "A
        Consistent Adjacency Spectral Embedding for Stochastic Blockmodel Graphs,"
        Journal of the American Statistical Association, Vol. 107(499), 2012
     """

--- a/graspy/embed/ase.py
+++ b/graspy/embed/ase.py
@@ -23,8 +23,8 @@ class AdjacencySpectralEmbed(BaseEmbed):
     Class for computing the adjacency spectral embedding of a graph 
     
     The adjacency spectral embedding (ASE) is a k-dimensional Euclidean representation 
-    of the graph based on its adjacency matrix [1]. It relies on an SVD to reduce the 
-    dimensionality to the specified k, or if k is unspecified, can find a number of 
+    of the graph based on its adjacency matrix :ref:`[1]`. It relies on an SVD to reduce
+    the dimensionality to the specified k, or if k is unspecified, can find a number of 
     dimensions automatically (see graspy.embed.selectSVD).
 
     Parameters
@@ -42,7 +42,7 @@ class AdjacencySpectralEmbed(BaseEmbed):
 
         - 'randomized'
             Computes randomized svd using 
-            ``sklearn.utils.extmath.randomized_svd``
+            :meth:`sklearn.utils.extmath.randomized_svd`
         - 'full'
             Computes full svd using ``scipy.linalg.svd``
         - 'truncated'

--- a/graspy/embed/ase.py
+++ b/graspy/embed/ase.py
@@ -23,7 +23,7 @@ class AdjacencySpectralEmbed(BaseEmbed):
     Class for computing the adjacency spectral embedding of a graph 
     
     The adjacency spectral embedding (ASE) is a k-dimensional Euclidean representation 
-    of the graph based on its adjacency matrix [1]_. It relies on an SVD to reduce the 
+    of the graph based on its adjacency matrix [1]. It relies on an SVD to reduce the 
     dimensionality to the specified k, or if k is unspecified, can find a number of 
     dimensions automatically (see graspy.embed.selectSVD).
 

--- a/graspy/embed/ase.py
+++ b/graspy/embed/ase.py
@@ -86,7 +86,7 @@ class AdjacencySpectralEmbed(BaseEmbed):
 
     References
     ----------
-    .. [1] Sussman, D.L., Tang, M., Fishkind, D.E., Priebe, C.E.  "A
+    .. _[1] Sussman, D.L., Tang, M., Fishkind, D.E., Priebe, C.E.  "A
        Consistent Adjacency Spectral Embedding for Stochastic Blockmodel Graphs,"
        Journal of the American Statistical Association, Vol. 107(499), 2012
     """

--- a/graspy/embed/lse.py
+++ b/graspy/embed/lse.py
@@ -27,6 +27,8 @@ class LaplacianSpectralEmbed(BaseEmbed):
     the dimensionality to the specified k, or if k is unspecified, can find a number
     of dimensions automatically.
 
+    Read more in the :ref:`tutorials <embed_tutorials>`
+
     Parameters
     ----------
     form : {'DAD' (default), 'I-DAD', 'R-DAD'}, optional
@@ -77,7 +79,7 @@ class LaplacianSpectralEmbed(BaseEmbed):
     latent_right_ : array, shape (n_samples, n_components), or None
         Only computed when the graph is directed, or adjacency matrix is assymetric.
         Estimated right latent positions of the graph. Otherwise, None.
-        
+
     singular_values_ : array, shape (n_components)
         Singular values associated with the latent position matrices.
 

--- a/graspy/embed/lse.py
+++ b/graspy/embed/lse.py
@@ -36,22 +36,23 @@ class LaplacianSpectralEmbed(BaseEmbed):
         Desired dimensionality of output data. If "full", 
         n_components must be <= min(X.shape). Otherwise, n_components must be
         < min(X.shape). If None, then optimal dimensions will be chosen by
-        ``select_dimension`` using ``n_elbows`` argument.
-    
+        :func:`~graspy.embed.select_dimension` using ``n_elbows`` argument.
+
     n_elbows : int, optional, default: 2
-        If `n_components=None`, then compute the optimal embedding dimension using
-        `select_dimension`. Otherwise, ignored.
+        If ``n_components=None``, then compute the optimal embedding dimension using
+        :func:`~graspy.embed.select_dimension`. Otherwise, ignored.
 
     algorithm : {'randomized' (default), 'full', 'truncated'}, optional
         SVD solver to use:
 
         - 'randomized'
             Computes randomized svd using 
-            ``sklearn.utils.extmath.randomized_svd``
+            :func:`sklearn.utils.extmath.randomized_svd`
         - 'full'
-            Computes full svd using ``scipy.linalg.svd``
+            Computes full svd using :func:`scipy.linalg.svd`
         - 'truncated'
-            Computes truncated svd using ``scipy.sparse.linalg.svd``
+            Computes truncated svd using :func:`scipy.sparse.linalg.svds`
+
     n_iter : int, optional (default = 5)
         Number of iterations for randomized SVD solver. Not used by 'full' or 
         'truncated'. The default is larger than the default in randomized_svd 
@@ -72,9 +73,11 @@ class LaplacianSpectralEmbed(BaseEmbed):
     ----------
     latent_left_ : array, shape (n_samples, n_components)
         Estimated left latent positions of the graph.
+
     latent_right_ : array, shape (n_samples, n_components), or None
         Only computed when the graph is directed, or adjacency matrix is assymetric.
         Estimated right latent positions of the graph. Otherwise, None.
+        
     singular_values_ : array, shape (n_components)
         Singular values associated with the latent position matrices.
 

--- a/graspy/embed/lse.py
+++ b/graspy/embed/lse.py
@@ -134,7 +134,7 @@ class LaplacianSpectralEmbed(BaseEmbed):
         Parameters
         ----------
         graph : array_like or networkx.Graph
-            Input graph to embed. see graphstats.utils.import_graph
+            Input graph to embed. see graspy.utils.import_graph
 
         y : Ignored
 

--- a/graspy/embed/mase.py
+++ b/graspy/embed/mase.py
@@ -221,7 +221,7 @@ class MultipleASE(BaseEmbedMulti):
 
         Returns
         -------
-        out : array-like, shape (n_graphs, n_vertices, n_components) if input 
+        out : array-like, shape (n_vertices, n_components) if input 
             graphs were symmetric. If graphs were directed, returns tuple of 
             two arrays (same shape as above) where the first corresponds to the
             left latent positions, and the right to the right latent positions

--- a/graspy/embed/mase.py
+++ b/graspy/embed/mase.py
@@ -84,7 +84,7 @@ class MultipleASE(BaseEmbedMulti):
     latent_right_ : array, shape (n_samples, n_components), or None
         Estimated right latent positions of the graph. Only computed when the an input 
         graph is directed, or adjacency matrix is assymetric. Otherwise, None.
-        
+
     scores_ : array, shape (n_samples, n_components, n_components)
         Estimated :math:`\hat{R}` matrices for each input graph.
 

--- a/graspy/embed/mase.py
+++ b/graspy/embed/mase.py
@@ -40,28 +40,32 @@ class MultipleASE(BaseEmbedMulti):
 
     Parameters
     ----------
-    n_components : int or None, (default=None)
-        Desired dimensionality of output data. If algorithm=="full", 
+    n_components : int or None, default = None
+        Desired dimensionality of output data. If "full", 
         n_components must be <= min(X.shape). Otherwise, n_components must be
         < min(X.shape). If None, then optimal dimensions will be chosen by
-        `select_dimension`.
-    n_elbows : int, optional (default=2)
-        If `n_compoents=None`, then compute the optimal embedding dimension using
-        `select_dimension`. Otherwise, ignored.
-    algorithm : {'full', 'truncated', 'randomized' (default)}, optional
+        :func:`~graspy.embed.select_dimension` using ``n_elbows`` argument.
+
+    n_elbows : int, optional, default: 2
+        If ``n_components=None``, then compute the optimal embedding dimension using
+        :func:`~graspy.embed.select_dimension`. Otherwise, ignored.
+
+    algorithm : {'randomized' (default), 'full', 'truncated'}, optional
         SVD solver to use:
 
-        - 'full'
-            Computes full svd using ``scipy.linalg.svd``
-        - 'truncated'
-            Computes truncated svd using ``scipy.sparse.linalg.svd``
         - 'randomized'
             Computes randomized svd using 
-            ``sklearn.utils.extmath.randomized_svd``
-    n_iter : int, optional (default=5)
+            :func:`sklearn.utils.extmath.randomized_svd`
+        - 'full'
+            Computes full svd using :func:`scipy.linalg.svd`
+        - 'truncated'
+            Computes truncated svd using :func:`scipy.sparse.linalg.svds`
+
+    n_iter : int, optional (default = 5)
         Number of iterations for randomized SVD solver. Not used by 'full' or 
         'truncated'. The default is larger than the default in randomized_svd 
         to handle sparse matrices that may have large slowly decaying spectrum.
+
     scaled : bool, optional (default=False)
         Whether to scale individual eigenvectors with eigenvalues in first embedding 
         stage.
@@ -70,13 +74,17 @@ class MultipleASE(BaseEmbedMulti):
     ----------
     n_graphs_ : int
         Number of graphs
+
     n_vertices_ : int
         Number of vertices in each graph
+
     latent_left_ : array, shape (n_samples, n_components)
         Estimated left latent positions of the graph. 
+
     latent_right_ : array, shape (n_samples, n_components), or None
         Estimated right latent positions of the graph. Only computed when the an input 
         graph is directed, or adjacency matrix is assymetric. Otherwise, None.
+        
     scores_ : array, shape (n_samples, n_components, n_components)
         Estimated :math:`\hat{R}` matrices for each input graph.
 

--- a/graspy/embed/mds.py
+++ b/graspy/embed/mds.py
@@ -53,7 +53,7 @@ class ClassicalMDS(BaseEstimator):
         ``select_dimension`` to find the optimal embedding dimension.
 
     n_elbows : int, or None (default=2)
-        If ``n_components=None`, then compute the optimal embedding dimension using
+        If ``n_components=None``, then compute the optimal embedding dimension using
         `:func:`~graspy.embed.select_dimension`. Otherwise, ignored.
 
     dissimilarity : 'euclidean' | 'precomputed', optional, default: 'euclidean'

--- a/graspy/embed/mds.py
+++ b/graspy/embed/mds.py
@@ -53,8 +53,8 @@ class ClassicalMDS(BaseEstimator):
         ``select_dimension`` to find the optimal embedding dimension.
 
     n_elbows : int, or None (default=2)
-        If `n_components=None`, then compute the optimal embedding dimension using
-        `select_dimension`. Otherwise, ignored.
+        If ``n_components=None`, then compute the optimal embedding dimension using
+        `:func:`~graspy.embed.select_dimension`. Otherwise, ignored.
 
     dissimilarity : 'euclidean' | 'precomputed', optional, default: 'euclidean'
         Dissimilarity measure to use:

--- a/graspy/embed/omni.py
+++ b/graspy/embed/omni.py
@@ -62,6 +62,8 @@ class OmnibusEmbed(BaseEmbedMulti):
     :math:`M_{ij} = \frac{1}{2}(A_i + A_j)`. The omnibus matrix is then embedded
     using adjacency spectral embedding [1]_.
 
+    Read more in the :ref:`tutorials <embed_tutorials>`
+
     Parameters
     ----------
     n_components : int or None, default = None

--- a/graspy/embed/omni.py
+++ b/graspy/embed/omni.py
@@ -68,24 +68,28 @@ class OmnibusEmbed(BaseEmbedMulti):
         Desired dimensionality of output data. If "full", 
         n_components must be <= min(X.shape). Otherwise, n_components must be
         < min(X.shape). If None, then optimal dimensions will be chosen by
-        ``select_dimension`` using ``n_elbows`` argument.
+        :func:`~graspy.embed.select_dimension` using ``n_elbows`` argument.
+
     n_elbows : int, optional, default: 2
-        If `n_components=None`, then compute the optimal embedding dimension using
-        `select_dimension`. Otherwise, ignored.
+        If ``n_components=None``, then compute the optimal embedding dimension using
+        :func:`~graspy.embed.select_dimension`. Otherwise, ignored.
+
     algorithm : {'randomized' (default), 'full', 'truncated'}, optional
         SVD solver to use:
 
         - 'randomized'
             Computes randomized svd using 
-            ``sklearn.utils.extmath.randomized_svd``
+            :func:`sklearn.utils.extmath.randomized_svd`
         - 'full'
-            Computes full svd using ``scipy.linalg.svd``
+            Computes full svd using :func:`scipy.linalg.svd`
         - 'truncated'
-            Computes truncated svd using ``scipy.sparse.linalg.svd``
+            Computes truncated svd using :func:`scipy.sparse.linalg.svds`
+
     n_iter : int, optional (default = 5)
         Number of iterations for randomized SVD solver. Not used by 'full' or 
         'truncated'. The default is larger than the default in randomized_svd 
         to handle sparse matrices that may have large slowly decaying spectrum.
+
     check_lcc : bool , optional (defult = True)
         Whether to check if the average of all input graphs are connected. May result
         in non-optimal results if the average graph is unconnected. If True and average
@@ -95,14 +99,18 @@ class OmnibusEmbed(BaseEmbedMulti):
     ----------
     n_graphs_ : int
         Number of graphs
+
     n_vertices_ : int
         Number of vertices in each graph
+
     latent_left_ : array, shape (n_graphs, n_vertices, n_components)
         Estimated left latent positions of the graph. 
+
     latent_right_ : array, shape (n_graphs, n_vertices, n_components), or None
         Only computed when the graph is directed, or adjacency matrix is 
         asymmetric. Estimated right latent positions of the graph. Otherwise, 
         None.
+
     singular_values_ : array, shape (n_components)
         Singular values associated with the latent position matrices.
 

--- a/graspy/embed/svd.py
+++ b/graspy/embed/svd.py
@@ -97,7 +97,7 @@ def select_dimension(
 
     References
     ----------
-    .. [1] Zhu, M. and Ghodsi, A. (2006).
+    .. [#1] Zhu, M. and Ghodsi, A. (2006).
         Automatic dimensionality selection from the scree plot via the use of
         profile likelihood. Computational Statistics & Data Analysis, 51(2), 
         pp.918-930.
@@ -198,20 +198,20 @@ def selectSVD(X, n_components=None, n_elbows=2, algorithm="randomized", n_iter=5
         Desired dimensionality of output data. If "full", 
         n_components must be <= min(X.shape). Otherwise, n_components must be
         < min(X.shape). If None, then optimal dimensions will be chosen by
-        ``select_dimension`` using ``n_elbows`` argument.
+        :func:`~graspy.embed.select_dimension` using ``n_elbows`` argument.
     n_elbows : int, optional, default: 2
-        If `n_components=None`, then compute the optimal embedding dimension using
-        `select_dimension`. Otherwise, ignored.
+        If ``n_components=None``, then compute the optimal embedding dimension using
+        :func:`~graspy.embed.select_dimension`. Otherwise, ignored.
     algorithm : {'randomized' (default), 'full', 'truncated'}, optional
         SVD solver to use:
 
         - 'randomized'
             Computes randomized svd using 
-            ``sklearn.utils.extmath.randomized_svd``
+            :func:`sklearn.utils.extmath.randomized_svd`
         - 'full'
-            Computes full svd using ``scipy.linalg.svd``
+            Computes full svd using :func:`scipy.linalg.svd`
         - 'truncated'
-            Computes truncated svd using ``scipy.sparse.linalg.svd``
+            Computes truncated svd using :func:`scipy.sparse.linalg.svds`
     n_iter : int, optional (default = 5)
         Number of iterations for randomized SVD solver. Not used by 'full' or 
         'truncated'. The default is larger than the default in randomized_svd 

--- a/graspy/inference/latent_distribution_test.py
+++ b/graspy/inference/latent_distribution_test.py
@@ -22,7 +22,7 @@ from .base import BaseInference
 class LatentDistributionTest(BaseInference):
     """
     Two-sample hypothesis test for the problem of determining whether two random 
-    dot product graphs have the same distributions of latent positions [2]_.
+    dot product graphs have the same distributions of latent positions [1]_.
     
     This test can operate on two graphs where there is no known matching between
     the vertices of the two graphs, or even when the number of vertices is different. 
@@ -55,7 +55,7 @@ class LatentDistributionTest(BaseInference):
 
     References
     ----------
-    .. [2] Tang, M., Athreya, A., Sussman, D. L., Lyzinski, V., & Priebe, C. E. (2017). 
+    .. [1] Tang, M., Athreya, A., Sussman, D. L., Lyzinski, V., & Priebe, C. E. (2017). 
         "A nonparametric two-sample hypothesis testing problem for random graphs."
         Bernoulli, 23(3), 1599-1630.
     """

--- a/graspy/inference/latent_distribution_test.py
+++ b/graspy/inference/latent_distribution_test.py
@@ -28,6 +28,8 @@ class LatentDistributionTest(BaseInference):
     the vertices of the two graphs, or even when the number of vertices is different. 
     Currently, testing is only supported for undirected graphs.
 
+    Read more in the :ref:`tutorials <inference_tutorials>`
+
     Parameters
     ----------
     n_components : int or None, optional (default=None)

--- a/graspy/inference/latent_position_test.py
+++ b/graspy/inference/latent_position_test.py
@@ -31,6 +31,8 @@ class LatentPositionTest(BaseInference):
     have their vertices sorted in the same order. Currently, the function only 
     supports undirected graphs.
 
+    Read more in the :ref:`tutorials <inference_tutorials>`
+
     Parameters
     ----------
     embedding : string, { 'ase' (default), 'omnibus'}

--- a/graspy/inference/latent_position_test.py
+++ b/graspy/inference/latent_position_test.py
@@ -56,10 +56,10 @@ class LatentPositionTest(BaseInference):
             .. math:: H_o: X_1 = X_2 R
         - 'scalar-rotation'
             .. math:: H_o: X_1 = c X_2 R
-            where `c` is a scalar, `c > 0`
+            where :math:`c` is a scalar, :math:`c > 0`
         - 'diagonal-rotation'
             .. math:: H_o: X_1 = D X_2 R
-            where `D` is an arbitrary diagonal matrix
+            where :math:`D` is an arbitrary diagonal matrix
 
     n_bootstraps : int, optional (default 500)
         Number of bootstrap simulations to run to generate the null distribution
@@ -74,7 +74,7 @@ class LatentPositionTest(BaseInference):
     
     sample_T_statistic_ : float
         The observed difference between the embedded positions of the two input graphs
-        after an alignment (the type of alignment depends on `test_case`)
+        after an alignment (the type of alignment depends on ``test_case``)
 
     p_value_1_, p_value_2_ : float 
         The p value estimated from the null distributions from sample 1 and sample 2. 

--- a/graspy/models/base.py
+++ b/graspy/models/base.py
@@ -100,7 +100,7 @@ class BaseGraphEstimator(BaseEstimator):
         
         Returns
         -------
-        sample_scores : np.ndarray (size of `graph`)
+        sample_scores : np.ndarray (size of ``graph``)
             log-likelihood per potential edge in the graph
         """
         check_is_fitted(self, "p_mat_")

--- a/graspy/models/er.py
+++ b/graspy/models/er.py
@@ -13,6 +13,8 @@ class EREstimator(SBMEstimator):
 
     :math:`P_{ij} = p` for all i, j
 
+    Read more in the :ref:`tutorials <models_tutorials>`
+
     Parameters
     ----------
     directed : boolean, optional (default=True)
@@ -70,6 +72,8 @@ class DCEREstimator(DCSBMEstimator):
     determines its expected degree in the graph. 
 
     :math:`P_{ij} = \theta_i \theta_j p`
+
+    Read more in the :ref:`tutorials <models_tutorials>`
 
     Parameters
     ----------

--- a/graspy/models/er.py
+++ b/graspy/models/er.py
@@ -24,6 +24,16 @@ class EREstimator(SBMEstimator):
         Whether to allow entries on the diagonal of the adjacency matrix, i.e. loops in 
         the graph where a node connects to itself. 
 
+    Attributes
+    ----------
+    p_ : float
+        Value between 0 and 1 (inclusive) representing the probability of any edge in 
+        the ER graph model 
+
+    p_mat_ : np.ndarray, shape (n_verts, n_verts)
+        Probability matrix :math:`P` for the fit model, from which graphs could be
+        sampled.         
+
     See also
     --------
     graspy.models.DCEREstimator
@@ -74,10 +84,26 @@ class DCEREstimator(DCSBMEstimator):
         Whether to allow seperate degree correction parameters for the in and out degree
         of each node. Ignored if `directed` is False.
     
+    Attributes
+    ----------
+    p_ : float
+        The :math:`p` parameter as described in the above model, which weights the
+        overall probability of connections between any two nodes.
+
+    p_mat_ : np.ndarray, shape (n_verts, n_verts)
+        Probability matrix :math:`P` for the fit model, from which graphs could be
+        sampled.
+
+    degree_corrections_ : np.ndarray, shape (n_verts, 1) or (n_verts, 2)
+        Degree correction vector(s) :math:`theta`. If `degree_directed` parameter was
+        False, then will be of shape (n_verts, 1) and element `i` represents the degree
+        correction for node `i`. Otherwise, the first column contains out degree
+        corrections and the second column contains in degree corrections. 
+
     Notes
     -----
-    The DCER model is rarely (if ever) mentioned in literature, though it is simply
-    a special case of the DCSBM where there is only one community.
+    The DCER model is rarely mentioned in literature, though it is simply a special case
+    of the DCSBM where there is only one community.
 
     See also
     --------

--- a/graspy/models/er.py
+++ b/graspy/models/er.py
@@ -20,6 +20,7 @@ class EREstimator(SBMEstimator):
         this determines whether to force symmetry upon the block probability matrix fit
         for the SBM. It will also determine whether graphs sampled from the model are 
         directed. 
+        
     loops : boolean, optional (default=False)
         Whether to allow entries on the diagonal of the adjacency matrix, i.e. loops in 
         the graph where a node connects to itself. 
@@ -77,9 +78,11 @@ class DCEREstimator(DCSBMEstimator):
         this determines whether to force symmetry upon the block probability matrix fit
         for the SBM. It will also determine whether graphs sampled from the model are 
         directed. 
+
     loops : boolean, optional (default=False)
         Whether to allow entries on the diagonal of the adjacency matrix, i.e. loops in 
         the graph where a node connects to itself. 
+
     degree_directed : boolean 
         Whether to allow seperate degree correction parameters for the in and out degree
         of each node. Ignored if `directed` is False.

--- a/graspy/models/er.py
+++ b/graspy/models/er.py
@@ -20,7 +20,7 @@ class EREstimator(SBMEstimator):
         this determines whether to force symmetry upon the block probability matrix fit
         for the SBM. It will also determine whether graphs sampled from the model are 
         directed. 
-        
+
     loops : boolean, optional (default=False)
         Whether to allow entries on the diagonal of the adjacency matrix, i.e. loops in 
         the graph where a node connects to itself. 
@@ -85,7 +85,7 @@ class DCEREstimator(DCSBMEstimator):
 
     degree_directed : boolean 
         Whether to allow seperate degree correction parameters for the in and out degree
-        of each node. Ignored if `directed` is False.
+        of each node. Ignored if ``directed`` is False.
     
     Attributes
     ----------
@@ -98,9 +98,9 @@ class DCEREstimator(DCSBMEstimator):
         sampled.
 
     degree_corrections_ : np.ndarray, shape (n_verts, 1) or (n_verts, 2)
-        Degree correction vector(s) :math:`theta`. If `degree_directed` parameter was
+        Degree correction vector(s) :math:`theta`. If ``degree_directed`` parameter was
         False, then will be of shape (n_verts, 1) and element `i` represents the degree
-        correction for node `i`. Otherwise, the first column contains out degree
+        correction for node :math:`i`. Otherwise, the first column contains out degree
         corrections and the second column contains in degree corrections. 
 
     Notes
@@ -116,7 +116,7 @@ class DCEREstimator(DCSBMEstimator):
 
     References
     ----------
-    .. [1] https://en.wikipedia.org/wiki/Erd%C5%91s%E2%80%93R%C3%A9nyi_model
+    .. [1]  https://en.wikipedia.org/wiki/Erd%C5%91s%E2%80%93R%C3%A9nyi_model
     .. [2]  Karrer, B., & Newman, M. E. (2011). Stochastic blockmodels and community
             structure in networks. Physical review E, 83(1), 016107.
 

--- a/graspy/models/rdpg.py
+++ b/graspy/models/rdpg.py
@@ -23,7 +23,7 @@ class RDPGEstimator(BaseGraphEstimator):
     is undirected, then :math:`x_i = y_i`. Latent positions can be estimated via 
     :class:`~graspy.embed.AdjacencySpectralEmbed`.
 
-    Read more in the :ref:`tutorials <models_tutorial>`
+    Read more in the :ref:`tutorials <models_tutorials>`
 
     Parameters
     ----------

--- a/graspy/models/rdpg.py
+++ b/graspy/models/rdpg.py
@@ -23,7 +23,7 @@ class RDPGEstimator(BaseGraphEstimator):
     is undirected, then :math:`x_i = y_i`. Latent positions can be estimated via 
     :class:`~graspy.embed.AdjacencySpectralEmbed`.
 
-    Read more in the :ref:`tutorials <models_tutorial>`
+    Read more in the :ref:`tutorials <model_tutorial>`
 
     Parameters
     ----------

--- a/graspy/models/rdpg.py
+++ b/graspy/models/rdpg.py
@@ -23,7 +23,7 @@ class RDPGEstimator(BaseGraphEstimator):
     is undirected, then :math:`x_i = y_i`. Latent positions can be estimated via 
     :class:`~graspy.embed.AdjacencySpectralEmbed`.
 
-    Read more in the :ref:`tutorials <model_tutorial>`
+    Read more in the :ref:`tutorials <models_tutorial>`
 
     Parameters
     ----------

--- a/graspy/models/rdpg.py
+++ b/graspy/models/rdpg.py
@@ -21,7 +21,7 @@ class RDPGEstimator(BaseGraphEstimator):
     where :math:`x_i` is the left latent position of node :math:`i`, and :math:`y_j` is 
     the right latent position of node :math:`j`. If the graph being modeled is
     is undirected, then :math:`x_i = y_i`. Latent positions can be estimated via 
-    :class:`embed.AdjacencySpectralEmbed`.
+    :class:`graspy.embed.AdjacencySpectralEmbed`.
 
     Parameters
     ----------

--- a/graspy/models/rdpg.py
+++ b/graspy/models/rdpg.py
@@ -21,7 +21,7 @@ class RDPGEstimator(BaseGraphEstimator):
     where :math:`x_i` is the left latent position of node :math:`i`, and :math:`y_j` is 
     the right latent position of node :math:`j`. If the graph being modeled is
     is undirected, then :math:`x_i = y_i`. Latent positions can be estimated via 
-    :class:`graspy.embed.AdjacencySpectralEmbed`.
+    :class:`~graspy.embed.AdjacencySpectralEmbed`.
 
     Parameters
     ----------

--- a/graspy/models/rdpg.py
+++ b/graspy/models/rdpg.py
@@ -37,7 +37,7 @@ class RDPGEstimator(BaseGraphEstimator):
     
     ase_kws : dict, optional (default={})
         Dictionary of keyword arguments passed down to 
-        `graspy.embed.AdjacencySpectralEmbed`, which is used to fit the model.
+        :class:`~graspy.embed.AdjacencySpectralEmbed`, which is used to fit the model.
 
     diag_aug_weight : int or float, optional (default=1)
         Weighting used for diagonal augmentation, which is a form of regularization for 

--- a/graspy/models/rdpg.py
+++ b/graspy/models/rdpg.py
@@ -16,10 +16,11 @@ class RDPGEstimator(BaseGraphEstimator):
     of nodes :math:`i` and :math:`j`, the probability of connection is the dot 
     product between their latent positions: 
 
-    :math:`P_{ij} = \langle x_i, x_j \rangle`
+    :math:`P_{ij} = \langle x_i, y_j \rangle`
 
-    where :math:`x_i` and :math:`x_j` are the latent positions of nodes :math:`i` and
-    :math:`j`, respectively.
+    where :math:`x_i` is the left latent position of node :math:`i`, and :math:`y_j` is 
+    the right latent position of node :math:`j`. If the graph being modeled is
+    is undirected, then :math:`x_i = y_i`.
 
     Parameters
     ----------
@@ -42,6 +43,20 @@ class RDPGEstimator(BaseGraphEstimator):
     plus_c_weight : int or float, optional (default=1)
         Weighting used for a constant scalar added to the adjacency matrix before 
         embedding as a form of regularization.
+
+    Attributes
+    ----------
+    latent_ : tuple, length 2, or np.ndarray, shape (n_verts, n_components)
+        The fit latent positions for the RDPG model. If a tuple, then the graph that was
+        input to fit was directed, and the first and second elements of the tuple are 
+        the left and right latent positions, respectively. The left and right latent
+        positions will both be of shape (n_verts, n_components). If `latent_` is an 
+        array, then the graph that was input to fit was undirected and the left and 
+        right latent positions are the same. 
+
+    p_mat_ : np.ndarray, shape (n_verts, n_verts)
+        Probability matrix :math:`P` for the fit model, from which graphs could be
+        sampled. 
 
     See also
     --------

--- a/graspy/models/rdpg.py
+++ b/graspy/models/rdpg.py
@@ -23,6 +23,8 @@ class RDPGEstimator(BaseGraphEstimator):
     is undirected, then :math:`x_i = y_i`. Latent positions can be estimated via 
     :class:`~graspy.embed.AdjacencySpectralEmbed`.
 
+    Read more in the :ref:`tutorials <models_tutorial>`
+
     Parameters
     ----------
     loops : boolean, optional (default=False)

--- a/graspy/models/rdpg.py
+++ b/graspy/models/rdpg.py
@@ -20,7 +20,8 @@ class RDPGEstimator(BaseGraphEstimator):
 
     where :math:`x_i` is the left latent position of node :math:`i`, and :math:`y_j` is 
     the right latent position of node :math:`j`. If the graph being modeled is
-    is undirected, then :math:`x_i = y_i`.
+    is undirected, then :math:`x_i = y_i`. Latent positions can be estimated via 
+    :class:`embed.AdjacencySpectralEmbed`.
 
     Parameters
     ----------

--- a/graspy/models/sbm.py
+++ b/graspy/models/sbm.py
@@ -340,7 +340,7 @@ class DCSBMEstimator(BaseGraphEstimator):
         self.n_components = n_components
         self.min_comm = min_comm
         self.max_comm = max_comm
-        self.embed_kws = {}
+        self.embed_kws = embed_kws
 
     def _estimate_assignments(self, graph):
         graph = symmetrize(graph, method="avg")  # TODO use directed LSE

--- a/graspy/models/sbm.py
+++ b/graspy/models/sbm.py
@@ -53,6 +53,8 @@ class SBMEstimator(BaseGraphEstimator):
     where :math:`B \in \mathbb{[0, 1]}^{K x K}` and :math:`\tau` is an `n\_nodes` 
     length vector specifying which block each node belongs to. 
 
+    Read more in the :ref:`tutorials <models_tutorials>`
+
     Parameters
     ----------
     directed : boolean, optional (default=True)
@@ -221,6 +223,8 @@ class DCSBMEstimator(BaseGraphEstimator):
 
     where :math:`\theta` and :math:`\eta` need not be the same.
     
+    Read more in the :ref:`tutorials <models_tutorials>`
+
     Parameters
     ----------
     directed : boolean, optional (default=True)

--- a/graspy/models/sbm.py
+++ b/graspy/models/sbm.py
@@ -64,6 +64,24 @@ class SBMEstimator(BaseGraphEstimator):
         Whether to allow entries on the diagonal of the adjacency matrix, i.e. loops in 
         the graph where a node connects to itself. 
 
+    Attributes
+    ----------
+    block_p_ : np.ndarray, shape (n_blocks, n_blocks)
+        The block probability matrix :math:`B`, where the element :math:`B_{i, j}`
+        represents the probability of an edge between block :math:`i` and block 
+        :math:`j`.
+
+    p_mat_ : np.ndarray, shape (n_verts, n_verts)
+        Probability matrix :math:`P` for the fit model, from which graphs could be
+        sampled.
+
+    vertex_assignments_ : np.ndarray, shape (n_verts)
+        A vector of integer labels corresponding to the predicted block that each node 
+        belongs to if `y` was not passed during the call to `fit`. 
+
+    block_weights_ : np.ndarray, shape (n_blocks)
+        Contains the proportion of nodes that belong to each block in the fit model.
+
     See also
     --------
     graspy.models.DCSBMEstimator
@@ -216,6 +234,30 @@ class DCSBMEstimator(BaseGraphEstimator):
     loops : boolean, optional (default=False)
         Whether to allow entries on the diagonal of the adjacency matrix, i.e. loops in 
         the graph where a node connects to itself. 
+
+    Attributes
+    ----------
+    block_p_ : np.ndarray, shape (n_blocks, n_blocks)
+        The block probability matrix :math:`B`, where the element :math:`B_{i, j}`
+        represents the expected number of edges between block :math:`i` and block 
+        :math:`j`.
+
+    p_mat_ : np.ndarray, shape (n_verts, n_verts)
+        Probability matrix :math:`P` for the fit model, from which graphs could be
+        sampled.
+
+    degree_corrections_ : np.ndarray, shape (n_verts, 1) or (n_verts, 2)
+        Degree correction vector(s) :math:`theta`. If `degree_directed` parameter was
+        False, then will be of shape (n_verts, 1) and element `i` represents the degree
+        correction for node `i`. Otherwise, the first column contains out degree
+        corrections and the second column contains in degree corrections. 
+
+    vertex_assignments_ : np.ndarray, shape (n_verts)
+        A vector of integer labels corresponding to the predicted block that each node 
+        belongs to if `y` was not passed during the call to `fit`. 
+
+    block_weights_ : np.ndarray, shape (n_blocks)
+        Contains the proportion of nodes that belong to each block in the fit model.
 
     See also
     --------

--- a/graspy/models/sbm.py
+++ b/graspy/models/sbm.py
@@ -67,6 +67,23 @@ class SBMEstimator(BaseGraphEstimator):
         Whether to allow entries on the diagonal of the adjacency matrix, i.e. loops in 
         the graph where a node connects to itself. 
 
+    n_components : int, optional (default=None)
+        Desired dimensionality of embedding for clustering to find communities.
+        ``n_components`` must be ``< min(X.shape)``. If None, then optimal dimensions 
+        will be chosen by :func:`~graspy.embed.select_dimension``.
+
+    min_comm : int, optional (default=1)
+        The minimum number of communities (blocks) to consider. 
+
+    max_comm : int, optional (default=10)
+        The maximum number of communities (blocks) to consider (inclusive).
+
+    cluster_kws : dict, optional (default={})
+        Additional kwargs passed down to :class:`~graspy.cluster.GaussianCluster`
+    
+    embed_kws : dict, optional (default={})
+        Additional kwargs passed down to :class:`~graspy.embed.AdjacencySpectralEmbed`
+
     Attributes
     ----------
     block_p_ : np.ndarray, shape (n_blocks, n_blocks)
@@ -232,13 +249,32 @@ class DCSBMEstimator(BaseGraphEstimator):
         this determines whether to force symmetry upon the block probability matrix fit
         for the SBM. It will also determine whether graphs sampled from the model are 
         directed. 
+
     degree_directed : boolean, optional (default=False)
         Whether to fit an "in" and "out" degree correction for each node. In the
         degree_directed case, the fit model can have a different expected in and out 
         degree for each node. 
+
     loops : boolean, optional (default=False)
         Whether to allow entries on the diagonal of the adjacency matrix, i.e. loops in 
         the graph where a node connects to itself. 
+
+    n_components : int, optional (default=None)
+        Desired dimensionality of embedding for clustering to find communities.
+        ``n_components`` must be ``< min(X.shape)``. If None, then optimal dimensions 
+        will be chosen by :func:`~graspy.embed.select_dimension``.
+
+    min_comm : int, optional (default=1)
+        The minimum number of communities (blocks) to consider. 
+
+    max_comm : int, optional (default=10)
+        The maximum number of communities (blocks) to consider (inclusive).
+
+    cluster_kws : dict, optional (default={})
+        Additional kwargs passed down to :class:`~graspy.cluster.GaussianCluster`
+    
+    embed_kws : dict, optional (default={})
+        Additional kwargs passed down to :class:`~graspy.embed.LaplacianSpectralEmbed`
 
     Attributes
     ----------
@@ -307,7 +343,7 @@ class DCSBMEstimator(BaseGraphEstimator):
         self.embed_kws = {}
 
     def _estimate_assignments(self, graph):
-        graph = symmetrize(graph, method="avg")
+        graph = symmetrize(graph, method="avg")  # TODO use directed LSE
         lse = LaplacianSpectralEmbed(
             form="R-DAD", n_components=self.n_components, **self.embed_kws
         )

--- a/graspy/models/sbm.py
+++ b/graspy/models/sbm.py
@@ -60,6 +60,7 @@ class SBMEstimator(BaseGraphEstimator):
         this determines whether to force symmetry upon the block probability matrix fit
         for the SBM. It will also determine whether graphs sampled from the model are 
         directed. 
+        
     loops : boolean, optional (default=False)
         Whether to allow entries on the diagonal of the adjacency matrix, i.e. loops in 
         the graph where a node connects to itself. 

--- a/graspy/models/sbm.py
+++ b/graspy/models/sbm.py
@@ -60,7 +60,7 @@ class SBMEstimator(BaseGraphEstimator):
         this determines whether to force symmetry upon the block probability matrix fit
         for the SBM. It will also determine whether graphs sampled from the model are 
         directed. 
-        
+
     loops : boolean, optional (default=False)
         Whether to allow entries on the diagonal of the adjacency matrix, i.e. loops in 
         the graph where a node connects to itself. 
@@ -78,7 +78,7 @@ class SBMEstimator(BaseGraphEstimator):
 
     vertex_assignments_ : np.ndarray, shape (n_verts)
         A vector of integer labels corresponding to the predicted block that each node 
-        belongs to if `y` was not passed during the call to `fit`. 
+        belongs to if ``y`` was not passed during the call to ``fit``. 
 
     block_weights_ : np.ndarray, shape (n_blocks)
         Contains the proportion of nodes that belong to each block in the fit model.
@@ -214,7 +214,7 @@ class DCSBMEstimator(BaseGraphEstimator):
     is an `n\_nodes` length vector specifiying the degree correction for each
     node. 
 
-    The `degree_directed` parameter of this model allows the degree correction 
+    The ``degree_directed`` parameter of this model allows the degree correction 
     parameter to be different for the in and out degree of each node:  
 
     :math:`P_{ij} = \theta_i \eta_j B_{\tau_i \tau_j}`
@@ -249,13 +249,13 @@ class DCSBMEstimator(BaseGraphEstimator):
 
     degree_corrections_ : np.ndarray, shape (n_verts, 1) or (n_verts, 2)
         Degree correction vector(s) :math:`theta`. If `degree_directed` parameter was
-        False, then will be of shape (n_verts, 1) and element `i` represents the degree
-        correction for node `i`. Otherwise, the first column contains out degree
-        corrections and the second column contains in degree corrections. 
+        False, then will be of shape (n_verts, 1) and element :math:`i` represents the 
+        degree correction for node :math:`i`. Otherwise, the first column contains out 
+        degree corrections and the second column contains in degree corrections. 
 
     vertex_assignments_ : np.ndarray, shape (n_verts)
         A vector of integer labels corresponding to the predicted block that each node 
-        belongs to if `y` was not passed during the call to `fit`. 
+        belongs to if ``y`` was not passed during the call to ``fit``. 
 
     block_weights_ : np.ndarray, shape (n_blocks)
         Contains the proportion of nodes that belong to each block in the fit model.
@@ -332,7 +332,7 @@ class DCSBMEstimator(BaseGraphEstimator):
 
         Returns
         -------
-        self : DCSBMEstimator object 
+        self : ``DCSBMEstimator`` object 
             Fitted instance of self 
         """
         graph = import_graph(graph)

--- a/graspy/pipeline/mug2vec.py
+++ b/graspy/pipeline/mug2vec.py
@@ -66,8 +66,8 @@ class mug2vec(BaseEstimator):
         ``select_dimension`` using ``n_elbows`` argument.
 
     omnibus_n_elbows, cmds_n_elbows: int, optional, default: 2
-        If `n_components=None`, then compute the optimal embedding dimension using
-        `select_dimension`. Otherwise, ignored.
+        If ``n_components=None``, then compute the optimal embedding dimension using
+        ``select_dimension``. Otherwise, ignored.
     
     Attributes
     ----------

--- a/graspy/plot/plot.py
+++ b/graspy/plot/plot.py
@@ -166,10 +166,13 @@ def heatmap(
     r"""
     Plots a graph as a heatmap.
 
+    Read more in the :ref:`tutorials <plot_tutorials>`
+
     Parameters
     ----------
     X : nx.Graph or np.ndarray object
         Graph or numpy matrix to plot
+
     transform : None, or string {'log', 'log10', 'zero-boost', 'simple-all', 'simple-nonzero'}
 
         - 'log' :
@@ -187,41 +190,56 @@ def heatmap(
         - 'simple-nonzero':
             Pass to ranks method. Same as simple-all, but ranks are scaled by
             :math:`\frac{rank(\text{non-zero edges})}{\text{# non-zero edges} + 1}`
+
     figsize : tuple of integers, optional, default: (10, 10)
         Width, height in inches.
+
     title : str, optional, default: None
         Title of plot.
+
     context :  None, or one of {paper, notebook, talk (default), poster}
         The name of a preconfigured set.
+
     font_scale : float, optional, default: 1
         Separate scaling factor to independently scale the size of the font
         elements.
+
     xticklabels, yticklabels : bool or list, optional
         If list-like, plot these alternate labels as the ticklabels.
+
     cmap : str, list of colors, or matplotlib.colors.Colormap, default: 'RdBu_r'
         Valid matplotlib color map.
+
     vmin, vmax : floats, optional (default=None)
         Values to anchor the colormap, otherwise they are inferred from the data and 
         other keyword arguments.
+
     center : float, default: 0
         The value at which to center the colormap
+
     cbar : bool, default: True
         Whether to draw a colorbar.
+
     inner_hier_labels : array-like, length of X's first dimension, default: None
         Categorical labeling of the nodes. If not None, will group the nodes 
         according to these labels and plot the labels on the marginal
+
     outer_hier_labels : array-like, length of X's first dimension, default: None
         Categorical labeling of the nodes, ignored without ``inner_hier_labels``
         If not None, will plot these labels as the second level of a hierarchy on the
         marginals 
+
     hier_label_fontsize : int
         size (in points) of the text labels for the ``inner_hier_labels`` and 
         ``outer_hier_labels``.
+
     ax : matplotlib Axes, optional
         Axes in which to draw the plot, otherwise will generate its own axes
+
     title_pad : int, float or None, optional (default=None)
         Custom padding to use for the distance of the title from the heatmap. Autoscales
         if ``None``
+
     sort_nodes : boolean, optional (default=False)
         whether or not to sort the nodes of the graph by the sum of edge weights
         (degree for an unweighted graph). If ``inner_hier_labels`` is passed and 
@@ -340,6 +358,8 @@ def gridplot(
     r"""
     Plots multiple graphs as a grid, with intensity denoted by the size 
     of dots on the grid.
+
+    Read more in the :ref:`tutorials <plot_tutorials>`
 
     Parameters
     ----------
@@ -509,6 +529,8 @@ def pairplot(
     plot in the 3rd row, 4th column would be 3rd dimension plotted against the 4th). The
     diagonal of the grid displays the marginals of individual dimensions as histograms 
     or KDEs. 
+
+    Read more in the :ref:`tutorials <plot_tutorials>`
 
     Parameters
     ----------

--- a/graspy/plot/plot.py
+++ b/graspy/plot/plot.py
@@ -211,21 +211,21 @@ def heatmap(
         Categorical labeling of the nodes. If not None, will group the nodes 
         according to these labels and plot the labels on the marginal
     outer_hier_labels : array-like, length of X's first dimension, default: None
-        Categorical labeling of the nodes, ignored without `inner_hier_labels`
+        Categorical labeling of the nodes, ignored without ``inner_hier_labels``
         If not None, will plot these labels as the second level of a hierarchy on the
         marginals 
     hier_label_fontsize : int
-        size (in points) of the text labels for the `inner_hier_labels` and 
-        `outer_hier_labels`.
+        size (in points) of the text labels for the ``inner_hier_labels`` and 
+        ``outer_hier_labels``.
     ax : matplotlib Axes, optional
         Axes in which to draw the plot, otherwise will generate its own axes
     title_pad : int, float or None, optional (default=None)
         Custom padding to use for the distance of the title from the heatmap. Autoscales
-        if `None`
+        if ``None``
     sort_nodes : boolean, optional (default=False)
         whether or not to sort the nodes of the graph by the sum of edge weights
-        (degree for an unweighted graph). If `inner_hier_labels` is passed and 
-        `sort_nodes` is `True`, will sort nodes this way within block. 
+        (degree for an unweighted graph). If ``inner_hier_labels`` is passed and 
+        ``sort_nodes`` is ``True``, will sort nodes this way within block. 
     """
     _check_common_inputs(
         figsize=figsize,
@@ -347,7 +347,7 @@ def gridplot(
         List of nx.Graph or numpy arrays to plot
     labels : list of str
         List of strings, which are labels for each element in X. 
-        `len(X) == len(labels)`.
+        ``len(X) == len(labels)``.
     transform : None, or string {'log', 'log10', 'zero-boost', 'simple-all', 'simple-nonzero'}
 
         - 'log' :
@@ -375,7 +375,7 @@ def gridplot(
         Separate scaling factor to independently scale the size of the font
         elements.
     palette : str, dict, optional, default: 'Set1'
-        Set of colors for mapping the `hue` variable. If a dict, keys should
+        Set of colors for mapping the ``hue`` variable. If a dict, keys should
         be values in the hue variable
     alpha : float [0, 1], default : 0.7
         alpha value of plotted gridplot points
@@ -387,19 +387,19 @@ def gridplot(
         Categorical labeling of the nodes. If not None, will group the nodes 
         according to these labels and plot the labels on the marginal
     outer_hier_labels : array-like, length of X's first dimension, default: None
-        Categorical labeling of the nodes, ignored without `inner_hier_labels`
+        Categorical labeling of the nodes, ignored without ``inner_hier_labels``
         If not None, will plot these labels as the second level of a hierarchy on the
         marginals
     hier_label_fontsize : int
-        size (in points) of the text labels for the `inner_hier_labels` and 
-        `outer_hier_labels`.
+        size (in points) of the text labels for the ``inner_hier_labels`` and 
+        ``outer_hier_labels``.
     title_pad : int, float or None, optional (default=None)
         Custom padding to use for the distance of the title from the heatmap. Autoscales
-        if `None`
+        if ``None``
     sort_nodes : boolean, optional (default=False)
         whether or not to sort the nodes of the graph by the sum of edge weights
-        (degree for an unweighted graph). If `inner_hier_labels` is passed and 
-        `sort_nodes` is `True`, will sort nodes this way within block. 
+        (degree for an unweighted graph). If ``inner_hier_labels`` is passed and 
+        ``sort_nodes`` is ``True``, will sort nodes this way within block. 
     """
     _check_common_inputs(
         height=height,
@@ -534,7 +534,7 @@ def pairplot(
         Separate scaling factor to independently scale the size of the font 
         elements.
     palette : str, dict, optional, default: 'Set1'
-        Set of colors for mapping the `hue` variable. If a dict, keys should
+        Set of colors for mapping the ``hue`` variable. If a dict, keys should
         be values in the hue variable.
     alpha : float, optional, default: 0.7
         opacity value of plotter markers between 0 and 1 
@@ -710,7 +710,7 @@ def degreeplot(
         Separate scaling factor to independently scale the size of the font 
         elements.
     palette : str, dict, optional, default: 'Set1'
-        Set of colors for mapping the `hue` variable. If a dict, keys should
+        Set of colors for mapping the ``hue`` variable. If a dict, keys should
         be values in the hue variable.
     figsize : tuple of length 2, default (10, 5)
         size of the figure (width, height)
@@ -776,7 +776,7 @@ def edgeplot(
         Separate scaling factor to independently scale the size of the font 
         elements.
     palette : str, dict, optional, default: 'Set1'
-        Set of colors for mapping the `hue` variable. If a dict, keys should
+        Set of colors for mapping the ``hue`` variable. If a dict, keys should
         be values in the hue variable.
     figsize : tuple of length 2, default (10, 5)
         size of the figure (width, height)
@@ -820,7 +820,7 @@ def screeplot(
 ):
     r"""
     Plots the distribution of singular values for a matrix, either showing the 
-    raw distribution or an empirical CDF (depending on `cumulative`)
+    raw distribution or an empirical CDF (depending on ``cumulative``)
 
     Parameters
     ----------
@@ -838,7 +838,7 @@ def screeplot(
     cumulative : boolean, default: True
         whether or not to plot a cumulative cdf of singular values 
     show_first : int or None, default: None 
-        whether to restrict the plot to the first `show_first` components
+        whether to restrict the plot to the first ``show_first`` components
 
     Returns
     -------

--- a/graspy/plot/plot.py
+++ b/graspy/plot/plot.py
@@ -504,6 +504,12 @@ def pairplot(
     r"""
     Plot pairwise relationships in a dataset.
 
+    For Euclidean data with more than 2 dimensions, pairplot will plot all possible
+    pairs of dimensions against each other, arranging the plots on a 2-d grid (i.e.) the 
+    plot in the 3rd row, 4th column would be 3rd dimension plotted against the 4th). The
+    diagonal of the grid displays the marginals of individual dimensions as histograms 
+    or KDEs. 
+
     Parameters
     ----------
     X : array-like, shape (n_samples, n_features)

--- a/graspy/simulations/simulations.py
+++ b/graspy/simulations/simulations.py
@@ -77,25 +77,33 @@ def er_np(n, p, directed=False, loops=False, wt=1, wtargs=None, dc=None, dc_kws=
     Erdos Renyi (n, p) graph is a simple graph with n vertices and a probability
     p of edges being connected.
 
+    Read more in the :ref:`tutorials <simulations_tutorials>`
+
     Parameters
     ----------
     n: int
        Number of vertices
+
     p: float
         Probability of an edge existing between two vertices, between 0 and 1.
+
     directed: boolean, optional (default=False)
         If False, output adjacency matrix will be symmetric. Otherwise, output adjacency
         matrix will be asymmetric.
+
     loops: boolean, optional (default=False)
         If False, no edges will be sampled in the diagonal. Otherwise, edges
         are sampled in the diagonal.
+
     wt: object, optional (default=1)
         Weight function for each of the edges, taking only a size argument. 
         This weight function will be randomly assigned for selected edges. 
         If 1, graph produced is binary.
+
     wtargs: dictionary, optional (default=None)
         Optional arguments for parameters that can be passed
         to weight function ``wt``.
+        
     dc: function or array-like, shape (n_vertices)
         `dc` is used to generate a degree-corrected Erdos Renyi Model in
         which each node in the graph has a parameter to specify its expected degree
@@ -145,22 +153,29 @@ def er_nm(n, m, directed=False, loops=False, wt=1, wtargs=None):
     Erdos Renyi (n, m) graph is a simple graph with n vertices and exactly m
     number of total edges.
 
+    Read more in the :ref:`tutorials <simulations_tutorials>`
+
     Parameters
     ----------
     n: int
         Number of vertices
+
     m: int
         Number of edges, a value between 1 and :math:`n^2`.
+
     directed: boolean, optional (default=False)
         If False, output adjacency matrix will be symmetric. Otherwise, output adjacency
         matrix will be asymmetric.
+
     loops: boolean, optional (default=False)
         If False, no edges will be sampled in the diagonal. Otherwise, edges
         are sampled in the diagonal.
+
     wt: object, optional (default=1)
         Weight function for each of the edges, taking only a size argument. 
         This weight function will be randomly assigned for selected edges. 
         If 1, graph produced is binary.
+
     wtargs: dictionary, optional (default=None)
         Optional arguments for parameters that can be passed
         to weight function ``wt``.
@@ -256,20 +271,26 @@ def sbm(n, p, directed=False, loops=False, wt=1, wtargs=None, dc=None, dc_kws={}
     SBM produces a graph with specified communities, in which each community can
     have different sizes and edge probabilities. 
 
+    Read more in the :ref:`tutorials <simulations_tutorials>`
+
     Parameters
     ----------
     n: list of int, shape (n_communities)
         Number of vertices in each community. Communities are assigned n[0], n[1], ...
+
     p: array-like, shape (n_communities, n_communities)
         Probability of an edge between each of the communities, where p[i, j] indicates 
         the probability of a connection between edges in communities [i, j]. 
         0 < p[i, j] < 1 for all i, j.
+
     directed: boolean, optional (default=False)
         If False, output adjacency matrix will be symmetric. Otherwise, output adjacency
         matrix will be asymmetric.
+
     loops: boolean, optional (default=False)
         If False, no edges will be sampled in the diagonal. Otherwise, edges
         are sampled in the diagonal.
+
     wt: object or array-like, shape (n_communities, n_communities)
         if Wt is an object, a weight function to use globally over
         the sbm for assigning weights. 1 indicates to produce a binary
@@ -278,10 +299,12 @@ def sbm(n, p, directed=False, loops=False, wt=1, wtargs=None, dc=None, dc_kws={}
         between communities i and j. If the entry is a function, should
         accept an argument for size. An entry of Wt[i, j] = 1 will produce a
         binary subgraph over the i, j community.
+
     wtargs: dictionary or array-like, shape (n_communities, n_communities)
         if Wt is an object, Wtargs corresponds to the trailing arguments
         to pass to the weight function. If Wt is an array-like, Wtargs[i, j] 
         corresponds to trailing arguments to pass to Wt[i, j].
+
     dc: function or array-like, shape (n_vertices) or (n_communities), optional
         `dc` is used to generate a degree-corrected stochastic block model [1] in
         which each node in the graph has a parameter to specify its expected degree
@@ -525,29 +548,37 @@ def rdpg(X, Y=None, rescale=True, directed=False, loops=True, wt=1, wtargs=None)
     A binary random graph is then sampled from the P matrix described 
     by X (and possibly Y).
 
+    Read more in the :ref:`tutorials <simulations_tutorials>`
+
     Parameters
     ----------
     X: np.ndarray, shape (n_vertices, n_dimensions)
         latent position from which to generate a P matrix
         if Y is given, interpreted as the left latent position
+
     Y: np.ndarray, shape (n_vertices, n_dimensions) or None, optional
         right latent position from which to generate a P matrix
+
     rescale: boolean, optional (default=True)
         when rescale is True, will subtract the minimum value in 
         P (if it is below 0) and divide by the maximum (if it is
         above 1) to ensure that P has entries between 0 and 1. If
         False, elements of P outside of [0, 1] will be clipped
+
     directed: boolean, optional (default=False)
         If False, output adjacency matrix will be symmetric. Otherwise, output adjacency
         matrix will be asymmetric.
+
     loops: boolean, optional (default=True)
         If False, no edges will be sampled in the diagonal. Diagonal elements in P 
         matrix are removed prior to rescaling (see above) which may affect behavior.
         Otherwise, edges are sampled in the diagonal.
+
     wt: object, optional (default=1)
         Weight function for each of the edges, taking only a size argument. 
         This weight function will be randomly assigned for selected edges. 
         If 1, graph produced is binary.
+
     wtargs: dictionary, optional (default=None)
         Optional arguments for parameters that can be passed
         to weight function ``wt``.
@@ -601,13 +632,16 @@ def p_from_latent(X, Y=None, rescale=True, loops=True):
     X: np.ndarray, shape (n_vertices, n_dimensions)
         latent position from which to generate a P matrix
         if Y is given, interpreted as the left latent position
+
     Y: np.ndarray, shape (n_vertices, n_dimensions) or None, optional
         right latent position from which to generate a P matrix
+
     rescale: boolean, optional (default=True)
         when rescale is True, will subtract the minimum value in 
         P (if it is below 0) and divide by the maximum (if it is
         above 1) to ensure that P has entries between 0 and 1. If
         False, elements of P outside of [0, 1] will be clipped
+
     loops: boolean, optional (default=True)
         whether to allow elements on the diagonal (corresponding
         to self connections in a graph) in the returned P matrix. 


### PR DESCRIPTION
#### Reference Issues/PRs
Some of #240 

#### What does this implement/fix? Explain your changes.
- Document attributes in `Models`
- Explain what pairplot is doing better
- fix `MASE.fit_transform` docs
- Add lots of cross-references 
- Fix many places where `` should have been ````
- Some other changes to documentation, especially spacing

#### Any other comments?
- Some ambiguity with model selection based on whether or not `y` is passed, if it is, should the attribute `vertex_assignments_` just be equal to `y`? (a la mug2vec embedding dimensions) 

- I would love it if the "Read more in the **tutorials**" links actually went to the corresponding .ipynb file but I haven't been able to figure out how to set a label for something that is just in the `tutorial.rst` toctree
