### PR TITLE
Diagonal augmentation for weighted graphs

### DIFF
--- a/graspy/utils/utils.py
+++ b/graspy/utils/utils.py
@@ -574,7 +574,9 @@ def augment_diagonal(graph, weight=1):
     ----------
     graph: nx.Graph, nx.DiGraph, nx.MultiDiGraph, nx.MultiGraph, np.ndarray
         Input graph in any of the above specified formats. If np.ndarray, 
-        interpreted as an :math:`n \times n` adjacency matrix 
+        interpreted as an :math:`n \times n` adjacency matrix
+    weight: int
+         Weight to be applied to each index.
     
     Returns
     -------

--- a/graspy/utils/utils.py
+++ b/graspy/utils/utils.py
@@ -563,12 +563,11 @@ def get_multigraph_intersect_lcc(graphs, return_inds=False):
 
 def augment_diagonal(graph, weight=1):
     r"""
-    Replaces the diagonal of adjacency matrix with 
-    :math:`\frac{degree}{nverts - 1}` for the degree associated
-    with each node. 
+    Replaces the diagonal of adjacency matrix with the sum of the edge weight.
+    This is equivalent to the degree for a weighted network.
 
     For directed graphs, the degree used is the out degree (number) of 
-    edges leaving the vertex. Ignores self-loops when calculating degree
+    edges leaving the vertex. Ignores self-loops when calculating degree.
 
     Parameters
     ----------

--- a/graspy/utils/utils.py
+++ b/graspy/utils/utils.py
@@ -599,7 +599,7 @@ def augment_diagonal(graph, weight=1):
     divisor = graph.shape[0] - 1
     # use out degree for directed graph
     # ignore self loops in either case
-    degrees = np.count_nonzero(graph, axis=1)
+    degrees = np.sum(graph, axis=1)
     diag = weight * degrees / divisor
     graph += np.diag(diag)
     return graph

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,6 +39,10 @@ class TestToLaplace(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.A = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]])
+        cls.B = np.array([[0, 1, 1, 1],
+                          [0, 0, 0, 1],
+                          [0, 1, 0, 1],
+                          [0, 1, 1, 0]])
 
     def test_to_laplace_IDAD(self):
         expected_L_normed = [
@@ -100,6 +104,15 @@ class TestToLaplace(unittest.TestCase):
         with self.assertRaises(ValueError):
             gus.to_laplace(self.A, form="R-DAD", regularizer=-1.0)
 
+    def test_to_laplace_directed(self):
+        expected_L_normed = [
+            [0, 1 / 5, sqrt(5) / 10, 0.2],
+            [0, 0, 0, sqrt(15) / 15],
+            [0, sqrt(5) / 10, 0, sqrt(5) / 10],
+            [0, sqrt(5) / 10, 0.25, 0]
+        ]
+        L_normed = gus.to_laplace(self.B, form="R-DAD")
+        self.assertTrue(np.allclose(L_normed, expected_L_normed, rtol=1e-04))
 
 class TestChecks(unittest.TestCase):
     @classmethod

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -401,6 +401,25 @@ class TestDiagonalAugment(unittest.TestCase):
         A_aug = gus.augment_diagonal(A)
         np.testing.assert_array_equal(A_aug, expected)
 
+    def test_augment_diagonal_weighted(self):
+        A = np.array(
+            [
+                [0, 1, 1, 0, 0],
+                [1, 0, 0, 2, 1],
+                [1, 0, 0, 1, 1],
+                [0, 2, 1, 0, 0],
+                [0, 1, 1, 0, 0],
+            ]
+        )
+        expected = A.copy().astype(float)
+        expected[0, 0] = 3 * 2.0 / 4
+        expected[1, 1] = 3 * 3.0 / 4
+        expected[2, 2] = 3 * 3.0 / 4
+        expected[3, 3] = 3 * 2.0 / 4
+        expected[4, 4] = 3 * 2.0 / 4
+        A_aug = gus.augment_diagonal(A, weight=3)
+        np.testing.assert_array_equal(A_aug, expected)
+
     def test_lcc_bad_matrix(self):
         A = np.array([0, 1])
         with self.assertRaises(ValueError):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,10 +39,6 @@ class TestToLaplace(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.A = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]])
-        cls.B = np.array([[0, 1, 1, 1],
-                          [0, 0, 0, 1],
-                          [0, 1, 0, 1],
-                          [0, 1, 1, 0]])
 
     def test_to_laplace_IDAD(self):
         expected_L_normed = [
@@ -104,15 +100,6 @@ class TestToLaplace(unittest.TestCase):
         with self.assertRaises(ValueError):
             gus.to_laplace(self.A, form="R-DAD", regularizer=-1.0)
 
-    def test_to_laplace_directed(self):
-        expected_L_normed = [
-            [0, 1 / 5, sqrt(5) / 10, 0.2],
-            [0, 0, 0, sqrt(15) / 15],
-            [0, sqrt(5) / 10, 0, sqrt(5) / 10],
-            [0, sqrt(5) / 10, 0.25, 0]
-        ]
-        L_normed = gus.to_laplace(self.B, form="R-DAD")
-        self.assertTrue(np.allclose(L_normed, expected_L_normed, rtol=1e-04))
 
 class TestChecks(unittest.TestCase):
     @classmethod

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -362,9 +362,9 @@ class TestDiagonalAugment(unittest.TestCase):
         )
         expected = A.copy().astype(float)
         expected[0, 0] = 2.0 / 4
-        expected[1, 1] = 3.0 / 4
+        expected[1, 1] = 4.0 / 4
         expected[2, 2] = 3.0 / 4
-        expected[3, 3] = 2.0 / 4
+        expected[3, 3] = 3.0 / 4
         expected[4, 4] = 2.0 / 4
         A_aug = gus.augment_diagonal(A)
         np.testing.assert_array_equal(A_aug, expected)
@@ -381,30 +381,11 @@ class TestDiagonalAugment(unittest.TestCase):
         )
         expected = A.copy().astype(float)
         expected[0, 0] = 2.0 / 4
-        expected[1, 1] = 2.0 / 4
+        expected[1, 1] = 3.0 / 4
         expected[2, 2] = 3.0 / 4
-        expected[3, 3] = 1.0 / 4
+        expected[3, 3] = 2.0 / 4
         expected[4, 4] = 1.0 / 4
         A_aug = gus.augment_diagonal(A)
-        np.testing.assert_array_equal(A_aug, expected)
-
-    def test_augment_diagonal_weighted(self):
-        A = np.array(
-            [
-                [0, 1, 1, 0, 0],
-                [1, 0, 0, 2, 1],
-                [1, 0, 0, 1, 1],
-                [0, 2, 1, 0, 0],
-                [0, 1, 1, 0, 0],
-            ]
-        )
-        expected = A.copy().astype(float)
-        expected[0, 0] = 3 * 2.0 / 4
-        expected[1, 1] = 3 * 3.0 / 4
-        expected[2, 2] = 3 * 3.0 / 4
-        expected[3, 3] = 3 * 2.0 / 4
-        expected[4, 4] = 3 * 2.0 / 4
-        A_aug = gus.augment_diagonal(A, weight=3)
         np.testing.assert_array_equal(A_aug, expected)
 
     def test_lcc_bad_matrix(self):


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/neurodata/graspy/blob/master/CONTRIBUTING.md#pull-request-checklist
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->Fixes #261 


#### What does this implement/fix? Explain your changes.
Weighted graph functionality for augment_diagonal by adding up nonzero entries and dividing by (nverts-1). Also contains test.

#### Any other comments?

