### PR TITLE
Add diag aug as default for ASE, update diag aug behavior for directed

### DIFF
--- a/graspy/embed/ase.py
+++ b/graspy/embed/ase.py
@@ -75,11 +75,6 @@ class AdjacencySpectralEmbed(BaseEmbed):
         before embedding. Empirically, this produces latent position estimates closer
         to the ground truth. 
 
-    ptr : bool, optional (default = True) 
-        Whether to perform pass-to-ranks on the adjacency matrix before embedding. If 
-        the graph is unweighted, this operation does nothing. If it is weighted, the 
-        edge weights are converted to the their relative rank among all edge weights, 
-        and then normalized to between 0 and 1. 
 
     Attributes
     ----------
@@ -123,7 +118,6 @@ class AdjacencySpectralEmbed(BaseEmbed):
         n_iter=5,
         check_lcc=True,
         diag_aug=True,
-        ptr=True,
     ):
         super().__init__(
             n_components=n_components,
@@ -136,10 +130,6 @@ class AdjacencySpectralEmbed(BaseEmbed):
         if not isinstance(diag_aug, bool):
             raise TypeError("`diag_aug` must be of type bool")
         self.diag_aug = diag_aug
-
-        if not isinstance(ptr, bool):
-            raise TypeError("`ptr` must be of type bool")
-        self.ptr = ptr
 
     def fit(self, graph, y=None):
         """

--- a/graspy/embed/ase.py
+++ b/graspy/embed/ase.py
@@ -15,7 +15,7 @@
 import warnings
 
 from .base import BaseEmbed
-from ..utils import import_graph, is_fully_connected
+from ..utils import import_graph, is_fully_connected, augment_diagonal, pass_to_ranks
 
 
 class AdjacencySpectralEmbed(BaseEmbed):
@@ -104,6 +104,8 @@ class AdjacencySpectralEmbed(BaseEmbed):
         algorithm="randomized",
         n_iter=5,
         check_lcc=True,
+        diag_aug=True,
+        ptr=True,
     ):
         super().__init__(
             n_components=n_components,
@@ -112,6 +114,14 @@ class AdjacencySpectralEmbed(BaseEmbed):
             n_iter=n_iter,
             check_lcc=check_lcc,
         )
+
+        if not isinstance(diag_aug, bool):
+            raise TypeError("`diag_aug` must be of type bool")
+        self.diag_aug = diag_aug
+
+        if not isinstance(ptr, bool):
+            raise TypeError("`ptr` must be of type bool")
+        self.ptr = ptr
 
     def fit(self, graph, y=None):
         """
@@ -136,6 +146,12 @@ class AdjacencySpectralEmbed(BaseEmbed):
                     + "using ``graspy.utils.get_lcc``."
                 )
                 warnings.warn(msg, UserWarning)
+
+        if self.ptr:
+            A = pass_to_ranks(A, method="simple-nonzero")
+
+        if self.diag_aug:
+            A = augment_diagonal(A)
 
         self._reduce_dim(A)
         return self

--- a/graspy/embed/ase.py
+++ b/graspy/embed/ase.py
@@ -155,10 +155,6 @@ class AdjacencySpectralEmbed(BaseEmbed):
                 )
                 warnings.warn(msg, UserWarning)
 
-        if self.ptr:
-            if not is_unweighted(A):  # just to avoid expensive ranking if unweighted
-                A = pass_to_ranks(A, method="simple-nonzero")
-
         if self.diag_aug:
             A = augment_diagonal(A)
 

--- a/graspy/models/rdpg.py
+++ b/graspy/models/rdpg.py
@@ -114,7 +114,9 @@ class RDPGEstimator(BaseGraphEstimator):
             )
         graph = augment_diagonal(graph, weight=self.diag_aug_weight)
         graph += self.plus_c_weight / graph.size
-        ase = AdjacencySpectralEmbed(n_components=self.n_components, **self.ase_kws)
+        ase = AdjacencySpectralEmbed(
+            n_components=self.n_components, diag_aug=False, **self.ase_kws
+        )
         latent = ase.fit_transform(graph)
         self.latent_ = latent
         if type(self.latent_) == tuple:

--- a/graspy/utils/utils.py
+++ b/graspy/utils/utils.py
@@ -564,11 +564,10 @@ def get_multigraph_intersect_lcc(graphs, return_inds=False):
 def augment_diagonal(graph, weight=1):
     r"""
     Replaces the diagonal of an adjacency matrix with :math:`\frac{d}{nverts - 1}` where
-    :math:`d` is the degree vector for an unweighted graph and the sum of edge weights 
-    for each node for a weighted graph. For a directed graph the in/out :math:`d` is 
-    averaged.
+    :math:`d` is the degree vector for an unweighted graph and the sum of magnitude of 
+    edge weights for each node for a weighted graph. For a directed graph the in/out 
+    :math:`d` is averaged.
     
-
     Parameters
     ----------
     graph: nx.Graph, nx.DiGraph, nx.MultiDiGraph, nx.MultiGraph, np.ndarray

--- a/graspy/utils/utils.py
+++ b/graspy/utils/utils.py
@@ -563,19 +563,19 @@ def get_multigraph_intersect_lcc(graphs, return_inds=False):
 
 def augment_diagonal(graph, weight=1):
     r"""
-    Replaces the diagonal of adjacency matrix with the sum of the edge weight.
-    This is equivalent to the degree for a weighted network.
-
-    For directed graphs, the degree used is the out degree (number) of 
-    edges leaving the vertex. Ignores self-loops when calculating degree.
+    Replaces the diagonal of an adjacency matrix with :math:`\frac{d}{nverts - 1}` where
+    :math:`d` is the degree vector for an unweighted graph and the sum of edge weights 
+    for each node for a weighted graph. For a directed graph the in/out :math:`d` is 
+    averaged.
+    
 
     Parameters
     ----------
     graph: nx.Graph, nx.DiGraph, nx.MultiDiGraph, nx.MultiGraph, np.ndarray
         Input graph in any of the above specified formats. If np.ndarray, 
         interpreted as an :math:`n \times n` adjacency matrix
-    weight: int
-         Weight to be applied to each index.
+    weight: float/int
+        scalar value to multiply the new diagonal vector by
     
     Returns
     -------
@@ -595,12 +595,16 @@ def augment_diagonal(graph, weight=1):
     """
     graph = import_graph(graph)
     graph = remove_loops(graph)
+
     divisor = graph.shape[0] - 1
-    # use out degree for directed graph
-    # ignore self loops in either case
-    degrees = np.sum(graph, axis=1)
+
+    in_degrees = np.sum(graph, axis=0)
+    out_degrees = np.sum(graph, axis=1)
+    degrees = (in_degrees + out_degrees) / 2
+
     diag = weight * degrees / divisor
     graph += np.diag(diag)
+
     return graph
 
 

--- a/graspy/utils/utils.py
+++ b/graspy/utils/utils.py
@@ -598,8 +598,8 @@ def augment_diagonal(graph, weight=1):
 
     divisor = graph.shape[0] - 1
 
-    in_degrees = np.sum(graph, axis=0)
-    out_degrees = np.sum(graph, axis=1)
+    in_degrees = np.sum(np.abs(graph), axis=0)
+    out_degrees = np.sum(np.abs(graph), axis=1)
     degrees = (in_degrees + out_degrees) / 2
 
     diag = weight * degrees / divisor

--- a/tests/test_spectral_embed.py
+++ b/tests/test_spectral_embed.py
@@ -104,6 +104,12 @@ class TestAdjacencySpectralEmbed(unittest.TestCase):
             ase = AdjacencySpectralEmbed()
             ase.fit(A)
 
+    def test_input_checks(self):
+        with self.assertRaises(TypeError):
+            ase = AdjacencySpectralEmbed(ptr=100)
+        with self.assertRaises(TypeError):
+            ase = AdjacencySpectralEmbed(diag_aug="over 9000")
+
 
 class TestLaplacianSpectralEmbed(unittest.TestCase):
     def test_output_dim(self):

--- a/tests/test_spectral_embed.py
+++ b/tests/test_spectral_embed.py
@@ -105,9 +105,8 @@ class TestAdjacencySpectralEmbed(unittest.TestCase):
 
     def test_input_checks(self):
         with self.assertRaises(TypeError):
-            ase = AdjacencySpectralEmbed(ptr=100)
-        with self.assertRaises(TypeError):
             ase = AdjacencySpectralEmbed(diag_aug="over 9000")
+            ase.fit()
 
 
 class TestLaplacianSpectralEmbed(unittest.TestCase):

--- a/tests/test_spectral_embed.py
+++ b/tests/test_spectral_embed.py
@@ -1,5 +1,4 @@
 import unittest
-import graspy as gs
 import numpy as np
 from graspy.embed.ase import AdjacencySpectralEmbed
 from graspy.embed.lse import LaplacianSpectralEmbed

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -380,11 +380,11 @@ class TestDiagonalAugment(unittest.TestCase):
             ]
         )
         expected = A.copy().astype(float)
-        expected[0, 0] = 2.0 / 4
-        expected[1, 1] = 3.0 / 4
-        expected[2, 2] = 3.0 / 4
-        expected[3, 3] = 2.0 / 4
-        expected[4, 4] = 1.0 / 4
+        expected[0, 0] = 1.5 / 4
+        expected[1, 1] = 3 / 4
+        expected[2, 2] = 2.5 / 4
+        expected[3, 3] = 2.5 / 4
+        expected[4, 4] = 1.5 / 4
         A_aug = gus.augment_diagonal(A)
         np.testing.assert_array_equal(A_aug, expected)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -372,7 +372,7 @@ class TestDiagonalAugment(unittest.TestCase):
     def test_augment_diagonal_directed(self):
         A = np.array(
             [
-                [0, 1, 1, 0, 0],
+                [0, 1, -1, 0, 0],
                 [0, 0, 0, 2, 1],
                 [1, 0, 0, 1, 1],
                 [0, 2, 0, 0, 0],


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #287 
Fixes #59 

#### What does this implement/fix? Explain your changes.
 - Updates diag aug to use in and out degree 
 - Adds diagonal augmentation as a default for ASE with the option to turn it off

#### Any other comments?
 - Seems like we should definitely do augment diagonal for ASE, but what about omni? 
 - Should I add a short tutorial about diag-aug (I already wrote the simulation, would just have to write up some text to go with it) 
 - Is it worth saving the modified matrix that is actually embedded? Sometimes I like to make screeplots and the like, or just heatmap the matrix itself. 
