### PR TITLE
remove matplotlib backend code, add matplotlib dependency to setup.py

### DIFF
--- a/graspy/plot/__init__.py
+++ b/graspy/plot/__init__.py
@@ -2,4 +2,5 @@ import sys
 import matplotlib as mpl
 
 from .plot import heatmap, gridplot, pairplot, degreeplot, edgeplot, screeplot
+
 __all__ = ["heatmap", "gridplot", "pairplot", "degreeplot", "edgeplot", "screeplot"]

--- a/graspy/plot/__init__.py
+++ b/graspy/plot/__init__.py
@@ -1,13 +1,5 @@
 import sys
-
-# Handle matplotlib backend for different operating systems
 import matplotlib as mpl
 
-if sys.platform == "darwin":
-    mpl.use("tkAgg")
-elif sys.platform == "linux":
-    mpl.use("Agg")
-
 from .plot import heatmap, gridplot, pairplot, degreeplot, edgeplot, screeplot
-
 __all__ = ["heatmap", "gridplot", "pairplot", "degreeplot", "edgeplot", "screeplot"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ numpy>=1.8.1
 scikit-learn>=0.19.1
 scipy>=1.1.0
 seaborn>=0.9.0
+matplotlib>=3.0.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ REQUIRED_PACKAGES = [
     "scikit-learn>=0.19.1",
     "scipy>=1.1.0",
     "seaborn>=0.9.0",
-    "matplotlib>=3.0.0"
+    "matplotlib>=3.0.0",
 ]
 
 # Find GraSPy version.

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ REQUIRED_PACKAGES = [
     "scikit-learn>=0.19.1",
     "scipy>=1.1.0",
     "seaborn>=0.9.0",
+    "matplotlib>=3.0.0"
 ]
 
 # Find GraSPy version.


### PR DESCRIPTION
- added matplotlib >= 3.0 dependency to `requirements.txt` and `setup.py`
- removed backend changing based on system in `plot/__init__.py`

See https://github.com/matplotlib/matplotlib/issues/9017#issuecomment-422400771

matplotlib 3.0.0 fixed the backend fallback behavior, and we were having errors as a result of this block of code in `ndmg` as a result of using either Catalina or a weird python installation, currently unclear which.

I think with `matplotlib>=3.0.0` you guys don't need this.