### PR TITLE
Deprecate Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+os: linux
 dist: xenial
 language: python
 python:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 matrix:
   include:
     - python: 3.7
+    - python: 3.8
 cache: pip
 install:
 - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: xenial
 sudo: true
 language: python
 python:
-- '3.5'
 - '3.6'
 matrix:
   include:
@@ -10,11 +9,10 @@ matrix:
 cache: pip
 install:
 - pip install -r requirements.txt
-- pip install -U pytest pytest-cov pytest-doctestplus codecov
-- if [[ $TRAVIS_PYTHON_VERSION != '3.5' ]]; then travis_retry pip install black; fi
+- pip install -U pytest pytest-cov pytest-doctestplus codecov black
 script:
 - pytest graspy/ tests/
-- if [[ $TRAVIS_PYTHON_VERSION != '3.5' ]]; then black --check --diff ./graspy ./tests; fi
+- black --check --diff ./graspy ./tests
 after_success:
 - codecov
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: xenial
-sudo: true
 language: python
 python:
 - '3.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ jobs:
   include:
     - python: 3.6
     - python: 3.7
-    - python: 3.8
 cache: pip
 install:
 - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ dist: xenial
 language: python
 python:
 - '3.6'
-matrix:
+jobs:
   include:
+    - python: 3.6
     - python: 3.7
     - python: 3.8
 cache: pip

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This package is supported for *Linux* and *macOS*. The package has been tested o
 + Windows: 10 
 
 ### Python Requirements
-This package is written for Python3. Currently, it is supported for Python 3.6, 3.7, and 3.8.
+This package is written for Python3. Currently, it is supported for Python 3.6 and 3.7.
 
 ### Python Dependencies
 `GraSPy` mainly depends on the Python scientific stack.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This package is supported for *Linux* and *macOS*. The package has been tested o
 + Windows: 10 
 
 ### Python Requirements
-This package is written for Python3. Currently, it is supported for Python 3.5, 3.6, and 3.7.
+This package is written for Python3. Currently, it is supported for Python 3.6, 3.7, and 3.8.
 
 ### Python Dependencies
 `GraSPy` mainly depends on the Python scientific stack.

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r") as f:
 AUTHOR = ("Eric Bridgeford, Jaewon Chung, Benjamin Pedigo, Bijan Varjavand",)
 AUTHOR_EMAIL = "j1c@jhu.edu"
 URL = "https://github.com/neurodata/graspy"
-MINIMUM_PYTHON_VERSION = 3, 5  # Minimum of Python 3.5
+MINIMUM_PYTHON_VERSION = 3, 6  # Minimum of Python 3.5
 REQUIRED_PACKAGES = [
     "networkx>=2.1",
     "numpy>=1.8.1",
@@ -52,9 +52,9 @@ setup(
         "Topic :: Scientific/Engineering :: Mathematics",
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     packages=find_packages(),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ setup(
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
     ],
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
#### Reference Issues/PRs
Closes #344 

#### What does this implement/fix? Explain your changes.
Removes Python 3.5 as supported language
Updates Travis, setup.py, readme accordingly
A few minor changes to travis.yml just cause of warnings/info from Travis
