### PR TITLE
Latent distribution test size

### DIFF
--- a/graspy/inference/latent_distribution_test.py
+++ b/graspy/inference/latent_distribution_test.py
@@ -160,7 +160,7 @@ class LatentDistributionTest(BaseInference):
         if not isinstance(workers, int):
             msg = "workers must be an int, not {}".format(type(workers))
             raise TypeError(msg)
-        elif workers == 0 or workers < 1:
+        elif workers == 0 or workers < -1:
             msg = (
                 "{} is invalid number of workers, must be positive, or -1 (to use all)"
             )

--- a/graspy/inference/latent_distribution_test.py
+++ b/graspy/inference/latent_distribution_test.py
@@ -180,7 +180,7 @@ class LatentDistributionTest(BaseInference):
             if metric in _VALID_DISTANCES:
                 if test == "hsic":
                     msg = (
-                        f"{test} is a kernel-baed test, but {metric} "
+                        f"{test} is a kernel-based test, but {metric} "
                         "is a distance. results may not be optimal. it is "
                         "recomended to use either a different test or one of "
                         f"the kernels: {_VALID_KERNELS} as a metric."
@@ -193,7 +193,7 @@ class LatentDistributionTest(BaseInference):
             elif metric == "gaussian":
                 if test != "hsic":
                     msg = (
-                        f"{test} is a distance-baed test, but {metric} "
+                        f"{test} is a distance-based test, but {metric} "
                         "is a kernel. results may not be optimal. it is "
                         "recomended to use either a hisc as a test or one of "
                         f"the distances: {_VALID_DISTANCES} as a metric."
@@ -203,7 +203,7 @@ class LatentDistributionTest(BaseInference):
             else:
                 if test != "hsic":
                     msg = (
-                        f"{test} is a distance-baed test, but {metric} "
+                        f"{test} is a distance-based test, but {metric} "
                         "is a kernel. results may not be optimal. it is "
                         "recomended to use either a hisc as a test or one of "
                         f"the distances: {_VALID_DISTANCES} as a metric."

--- a/graspy/inference/latent_distribution_test.py
+++ b/graspy/inference/latent_distribution_test.py
@@ -161,7 +161,9 @@ class LatentDistributionTest(BaseInference):
             msg = "workers must be an int, not {}".format(type(workers))
             raise TypeError(msg)
         elif workers == 0 or workers < 1:
-            msg = "{} is invalid number of workers, must be positive, or -1 (to use all)"
+            msg = (
+                "{} is invalid number of workers, must be positive, or -1 (to use all)"
+            )
             raise ValueError(msg.format(workers))
 
         if not isinstance(size_correction, bool):

--- a/graspy/inference/latent_distribution_test.py
+++ b/graspy/inference/latent_distribution_test.py
@@ -139,6 +139,7 @@ class LatentDistributionTest(BaseInference):
         n_bootstraps=200,
         workers=1,
         size_correction=True,
+        pooled=False,
     ):
 
         if not isinstance(test, str):

--- a/graspy/inference/latent_distribution_test.py
+++ b/graspy/inference/latent_distribution_test.py
@@ -195,7 +195,6 @@ class LatentDistributionTest(BaseInference):
 
         return X1_hat, X2_hat
 
-
     def _estimate_correction_variances(self, X_hat, Y_hat, pooled=True):
         # TODO it is unclear whether using pooled estimator provides more or
         # less power. this should be investigated. should not matter under null.
@@ -222,7 +221,6 @@ class LatentDistributionTest(BaseInference):
             Y_sigmas = get_sigma(Y_hat) * (M - N) / (N * M)
         return X_sigmas, Y_sigmas
 
-
     def _sample_modified_ase(self, X, Y, workers=1):
         n = len(X)
         m = len(Y)
@@ -245,7 +243,6 @@ class LatentDistributionTest(BaseInference):
                 )
             return X, Y_sampled
 
-
     def fit(self, A1, A2):
         """
         Fits the test to the two input graphs
@@ -266,7 +263,9 @@ class LatentDistributionTest(BaseInference):
         X1_hat, X2_hat = _median_sign_flips(X1_hat, X2_hat)
 
         if self.size_correction:
-            X1_hat, X2_hat = self._sample_modified_ase(X1_hat, X2_hat, workers=self.workers)
+            X1_hat, X2_hat = self._sample_modified_ase(
+                X1_hat, X2_hat, workers=self.workers
+            )
 
         data = self.test.test(
             X1_hat, X2_hat, reps=self.n_bootstraps, workers=self.workers, auto=False
@@ -285,7 +284,7 @@ def _medial_gaussian_kernel(X, Y=None, workers=None):
     l1 = pairwise_distances(X, Y=Y, metric="cityblock")
     mask = np.ones(l1.shape, dtype=bool)
     np.fill_diagonal(mask, 0)
-    bandwidth = np.median(l1[mask]) if np.median(l1[mask]) else 1 # k-sample case
+    bandwidth = np.median(l1[mask]) if np.median(l1[mask]) else 1  # k-sample case
     gamma = 1.0 / (2 * bandwidth ** 2)
     K = np.exp(-gamma * pairwise_distances(X, Y=Y, metric="sqeuclidean"))
     return 1 - K / np.max(K)

--- a/graspy/inference/latent_distribution_test.py
+++ b/graspy/inference/latent_distribution_test.py
@@ -178,7 +178,7 @@ class LatentDistributionTest(BaseInference):
             raise TypeError(msg)
 
         if not isinstance(pooled, bool):
-            msg = "size_correction must be a bool, not {}".format(type(size_correction))
+            msg = "pooled must be a bool, not {}".format(type(pooled))
             raise TypeError(msg)
 
         super().__init__(n_components=n_components)

--- a/graspy/inference/latent_distribution_test.py
+++ b/graspy/inference/latent_distribution_test.py
@@ -234,7 +234,9 @@ class LatentDistributionTest(BaseInference):
             X1_hat = np.concatenate(X1_hat, axis=-1)
             X2_hat = np.concatenate(X2_hat, axis=-1)
         elif isinstance(X1_hat, tuple) ^ isinstance(X2_hat, tuple):
-            raise ValueError("Input graphs do not have same directedness")
+            msg = ("input graphs do not have same directedness. "
+                   "consider symmetrizing the directed graph.")
+            raise ValueError(msg)
 
         return X1_hat, X2_hat
 

--- a/graspy/inference/latent_distribution_test.py
+++ b/graspy/inference/latent_distribution_test.py
@@ -79,8 +79,8 @@ class LatentDistributionTest(BaseInference):
         Number of workers to use. If more than 1, parallelizes the code.
         Supply -1 to use all cores available to the Process.
 
-    size_correction: bool (default=True)
-        The size degrades in validity as the orders of two graphs diverge from
+    order_correction: bool (default=True)
+        The test degrades in validity as the orders of two graphs diverge from
         each other, unless the kernel matrix is modified.
         If True - in the case when two graphs are not of equal orders, estimates
         the plug-in estimator for the variance and uses it to correct the
@@ -126,7 +126,7 @@ class LatentDistributionTest(BaseInference):
         n_components=None,
         n_bootstraps=200,
         workers=1,
-        size_correction=True,
+        order_correction=True,
     ):
 
         if not isinstance(test, str):
@@ -166,8 +166,8 @@ class LatentDistributionTest(BaseInference):
             )
             raise ValueError(msg.format(workers))
 
-        if not isinstance(size_correction, bool):
-            msg = "size_correction must be a bool, not {}".format(type(size_correction))
+        if not isinstance(order_correction, bool):
+            msg = "order_correction must be a bool, not {}".format(type(order_correction))
             raise TypeError(msg)
 
         super().__init__(n_components=n_components)
@@ -214,7 +214,7 @@ class LatentDistributionTest(BaseInference):
         self.test = KSample(test, compute_distance=metric_func)
         self.n_bootstraps = n_bootstraps
         self.workers = workers
-        self.size_correction = size_correction
+        self.order_correction = order_correction
 
     def _embed(self, A1, A2):
         # if not is_symmetric(A1) or not is_symmetric(A2):
@@ -289,7 +289,7 @@ class LatentDistributionTest(BaseInference):
         X1_hat, X2_hat = self._embed(A1, A2)
         X1_hat, X2_hat = _median_sign_flips(X1_hat, X2_hat)
 
-        if self.size_correction:
+        if self.order_correction:
             X1_hat, X2_hat = self._sample_modified_ase(X1_hat, X2_hat)
 
         data = self.test.test(

--- a/graspy/inference/latent_distribution_test.py
+++ b/graspy/inference/latent_distribution_test.py
@@ -154,7 +154,7 @@ class LatentDistributionTest(BaseInference):
             msg = "n_bootstraps must be an int, not {}".format(type(n_bootstraps))
             raise TypeError(msg)
         elif n_bootstraps < 0:
-            msg = "{} is invalid number of bootstraps, must be positive"
+            msg = "{} is invalid number of bootstraps, must be non-negative"
             raise ValueError(msg.format(n_bootstraps))
 
         if not isinstance(workers, int):

--- a/graspy/inference/latent_distribution_test.py
+++ b/graspy/inference/latent_distribution_test.py
@@ -80,9 +80,9 @@ class LatentDistributionTest(BaseInference):
         Supply -1 to use all cores available to the Process.
 
     size_correction: bool (default=True)
-        The size degrades in validity as the sizes of two graphs diverge from
+        The size degrades in validity as the orders of two graphs diverge from
         each other, unless the kernel matrix is modified.
-        If True - in the case when two graphs are not of equal sizes, estimates
+        If True - in the case when two graphs are not of equal orders, estimates
         the plug-in estimator for the variance and uses it to correct the
         embedding of the larger graph.
         If False - does not perform any modifications (generally not
@@ -217,9 +217,9 @@ class LatentDistributionTest(BaseInference):
         self.size_correction = size_correction
 
     def _embed(self, A1, A2):
-        if not is_symmetric(A1) or not is_symmetric(A2):
-            msg = "currently, testing is only supported for undirected graphs"
-            raise NotImplementedError(msg)  # TODO asymmetric case
+        # if not is_symmetric(A1) or not is_symmetric(A2):
+        #     msg = "currently, testing is only supported for undirected graphs"
+        #     raise NotImplementedError(msg)  # TODO asymmetric case
 
         if self.n_components is None:
             num_dims1 = select_dimension(A1)[0][-1]
@@ -242,7 +242,6 @@ class LatentDistributionTest(BaseInference):
         N, M = len(X), len(Y)
 
         # return if graphs are same order, else else ensure X the larger graph.
-        print(X.shape, Y.shape)
         if N == M:
             return X, Y
         elif M > N:
@@ -252,8 +251,6 @@ class LatentDistributionTest(BaseInference):
         else:
             reverse_order = False
 
-        print(X.shape, Y.shape)
-        print(N, M, reverse_order)
         # estimate the central limit theorem variance
         if pooled:
             # TODO unclear whether using pooled estimator provides more power.
@@ -271,7 +268,6 @@ class LatentDistributionTest(BaseInference):
             X_sampled[i, :] = X[i, :] + stats.multivariate_normal.rvs(cov=X_sigmas[i])
 
         # return the embeddings in the appropriate order
-        print(X_sampled.shape)
         return (Y, X_sampled) if reverse_order else (X_sampled, Y)
 
     def fit(self, A1, A2):

--- a/graspy/inference/latent_distribution_test.py
+++ b/graspy/inference/latent_distribution_test.py
@@ -79,8 +79,8 @@ class LatentDistributionTest(BaseInference):
         Number of workers to use. If more than 1, parallelizes the code.
         Supply -1 to use all cores available to the Process.
 
-    order_correction: bool (default=True)
-        Ignored when the two graphs have the same number of vertices. The test degrades 
+    size_correction: bool (default=True)
+        Ignored when the two graphs have the same number of vertices. The test degrades
         in validity as the number of vertices of the two graphs diverge from each other,
         unless a correction is performed.
         If True, when the two graphs have different numbers of vertices, estimates
@@ -126,7 +126,7 @@ class LatentDistributionTest(BaseInference):
         n_components=None,
         n_bootstraps=200,
         workers=1,
-        order_correction=True,
+        size_correction=True,
     ):
 
         if not isinstance(test, str):
@@ -166,10 +166,8 @@ class LatentDistributionTest(BaseInference):
             )
             raise ValueError(msg.format(workers))
 
-        if not isinstance(order_correction, bool):
-            msg = "order_correction must be a bool, not {}".format(
-                type(order_correction)
-            )
+        if not isinstance(size_correction, bool):
+            msg = "size_correction must be a bool, not {}".format(type(size_correction))
             raise TypeError(msg)
 
         super().__init__(n_components=n_components)
@@ -216,7 +214,7 @@ class LatentDistributionTest(BaseInference):
         self.test = KSample(test, compute_distance=metric_func)
         self.n_bootstraps = n_bootstraps
         self.workers = workers
-        self.order_correction = order_correction
+        self.size_correction = size_correction
 
     def _embed(self, A1, A2):
         if self.n_components is None:
@@ -291,7 +289,7 @@ class LatentDistributionTest(BaseInference):
         X1_hat, X2_hat = self._embed(A1, A2)
         X1_hat, X2_hat = _median_sign_flips(X1_hat, X2_hat)
 
-        if self.order_correction:
+        if self.size_correction:
             X1_hat, X2_hat = self._sample_modified_ase(X1_hat, X2_hat)
 
         data = self.test.test(

--- a/graspy/inference/latent_distribution_test.py
+++ b/graspy/inference/latent_distribution_test.py
@@ -238,7 +238,7 @@ class LatentDistributionTest(BaseInference):
 
         return X1_hat, X2_hat
 
-    def _estimate_correction_variances(self, X_hat, Y_hat, pooled=True):
+    def _estimate_correction_variances(self, X_hat, Y_hat, pooled=False):
         # TODO it is unclear whether using pooled estimator provides more or
         # less power. this should be investigated. should not matter under null.
         N, d_X = X_hat.shape

--- a/graspy/inference/latent_distribution_test.py
+++ b/graspy/inference/latent_distribution_test.py
@@ -167,7 +167,9 @@ class LatentDistributionTest(BaseInference):
             raise ValueError(msg.format(workers))
 
         if not isinstance(order_correction, bool):
-            msg = "order_correction must be a bool, not {}".format(type(order_correction))
+            msg = "order_correction must be a bool, not {}".format(
+                type(order_correction)
+            )
             raise TypeError(msg)
 
         super().__init__(n_components=n_components)
@@ -234,8 +236,10 @@ class LatentDistributionTest(BaseInference):
             X1_hat = np.concatenate(X1_hat, axis=-1)
             X2_hat = np.concatenate(X2_hat, axis=-1)
         elif isinstance(X1_hat, tuple) ^ isinstance(X2_hat, tuple):
-            msg = ("input graphs do not have same directedness. "
-                   "consider symmetrizing the directed graph.")
+            msg = (
+                "input graphs do not have same directedness. "
+                "consider symmetrizing the directed graph."
+            )
             raise ValueError(msg)
 
         return X1_hat, X2_hat

--- a/graspy/inference/latent_distribution_test.py
+++ b/graspy/inference/latent_distribution_test.py
@@ -167,7 +167,7 @@ class LatentDistributionTest(BaseInference):
             raise ValueError(msg.format(workers))
 
         if not isinstance(size_correction, bool):
-            msg = "size_correction must be an int, not {}".format(type(size_correction))
+            msg = "size_correction must be a bool, not {}".format(type(size_correction))
             raise TypeError(msg)
 
         super().__init__(n_components=n_components)

--- a/graspy/inference/latent_distribution_test.py
+++ b/graspy/inference/latent_distribution_test.py
@@ -385,7 +385,7 @@ def _fit_plug_in_variance_estimator(X):
         # for i in range(n):
         #     middle_term += np.multiply.outer((x @ X[i] - (x @ X[i]) ** 2),
         #                                      np.outer(X[i], X[i]))
-        # the matrix part does not involve x and has been computed above
+        # where the matrix part does not involve x and has been computed above
         middle_term_scalar = x @ X.T - (x @ X.T) ** 2
         middle_term = np.tensordot(middle_term_scalar, middle_term_matrix, axes=1)
         covariances = delta_inverse @ (middle_term / n) @ delta_inverse

--- a/graspy/inference/latent_distribution_test.py
+++ b/graspy/inference/latent_distribution_test.py
@@ -80,13 +80,13 @@ class LatentDistributionTest(BaseInference):
         Supply -1 to use all cores available to the Process.
 
     order_correction: bool (default=True)
-        The test degrades in validity as the orders of two graphs diverge from
-        each other, unless the kernel matrix is modified.
-        If True - in the case when two graphs are not of equal orders, estimates
+        Ignored when the two graphs have the same number of vertices. The test degrades 
+        in validity as the number of vertices of the two graphs diverge from each other,
+        unless a correction is performed.
+        If True, when the two graphs have different numbers of vertices, estimates
         the plug-in estimator for the variance and uses it to correct the
         embedding of the larger graph.
-        If False - does not perform any modifications (generally not
-        recommended).
+        If False, does not perform any modifications (not recommended).
 
     Attributes
     ----------

--- a/graspy/inference/latent_distribution_test.py
+++ b/graspy/inference/latent_distribution_test.py
@@ -18,7 +18,7 @@ import numpy as np
 from scipy import stats
 
 from ..embed import select_dimension, AdjacencySpectralEmbed
-from ..utils import import_graph, is_symmetric
+from ..utils import import_graph
 from .base import BaseInference
 from sklearn.metrics import pairwise_distances
 from sklearn.metrics.pairwise import pairwise_kernels
@@ -219,10 +219,6 @@ class LatentDistributionTest(BaseInference):
         self.order_correction = order_correction
 
     def _embed(self, A1, A2):
-        # if not is_symmetric(A1) or not is_symmetric(A2):
-        #     msg = "currently, testing is only supported for undirected graphs"
-        #     raise NotImplementedError(msg)  # TODO asymmetric case
-
         if self.n_components is None:
             num_dims1 = select_dimension(A1)[0][-1]
             num_dims2 = select_dimension(A2)[0][-1]

--- a/graspy/inference/latent_distribution_test.py
+++ b/graspy/inference/latent_distribution_test.py
@@ -176,7 +176,7 @@ class LatentDistributionTest(BaseInference):
                         f"{test} is a kernel-baed test, but {metric} "
                         "is a distance. results may not be optimal. it is "
                         "recomended to use either a different test or one of "
-                        f'the kernels:" {_VALID_KERNELS} as a metric.'
+                        f"the kernels: {_VALID_KERNELS} as a metric."
                     )
                     warnings.warn(msg, UserWarning)
 
@@ -189,7 +189,7 @@ class LatentDistributionTest(BaseInference):
                         f"{test} is a distance-baed test, but {metric} "
                         "is a kernel. results may not be optimal. it is "
                         "recomended to use either a hisc as a test or one of "
-                        f'the distances:" {_VALID_DISTANCES} as a metric.'
+                        f"the distances: {_VALID_DISTANCES} as a metric."
                     )
                     warnings.warn(msg, UserWarning)
                 metric_func = _medial_gaussian_kernel
@@ -199,7 +199,7 @@ class LatentDistributionTest(BaseInference):
                         f"{test} is a distance-baed test, but {metric} "
                         "is a kernel. results may not be optimal. it is "
                         "recomended to use either a hisc as a test or one of "
-                        f'the distances:" {_VALID_DISTANCES} as a metric.'
+                        f"the distances: {_VALID_DISTANCES} as a metric."
                     )
                     warnings.warn(msg, UserWarning)
 

--- a/graspy/inference/latent_distribution_test.py
+++ b/graspy/inference/latent_distribution_test.py
@@ -160,11 +160,6 @@ class LatentDistributionTest(BaseInference):
         if not isinstance(workers, int):
             msg = "workers must be an int, not {}".format(type(workers))
             raise TypeError(msg)
-        elif workers == 0 or workers < -1:
-            msg = (
-                "{} is invalid number of workers, must be positive, or -1 (to use all)"
-            )
-            raise ValueError(msg.format(workers))
 
         if not isinstance(size_correction, bool):
             msg = "size_correction must be a bool, not {}".format(type(size_correction))

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ REQUIRED_PACKAGES = [
     "scipy>=1.1.0",
     "seaborn>=0.9.0",
     "matplotlib>=3.0.0",
-    "hyppo>=0.1.2",
+    "hyppo>=0.1.3",
 ]
 
 

--- a/tests/.#test_latentdistributiontest.py
+++ b/tests/.#test_latentdistributiontest.py
@@ -1,0 +1,1 @@
+antonalyakin@Antons-MacBook-Pro.local.32036

--- a/tests/.#test_latentdistributiontest.py
+++ b/tests/.#test_latentdistributiontest.py
@@ -1,1 +1,0 @@
-antonalyakin@Antons-MacBook-Pro.local.32036

--- a/tests/test_latentdistributiontest.py
+++ b/tests/test_latentdistributiontest.py
@@ -69,7 +69,7 @@ class TestLatentDistributionTest(unittest.TestCase):
         A2 = er_np(100, 0.3)
 
         ldt = LatentDistributionTest(pooled=True)
-        ldt.fit(self.A1, self.A2)
+        ldt.fit(A1, A2)
 
     def test_distances_and_kernels(self):
         # some valid combinations of test and metric

--- a/tests/test_latentdistributiontest.py
+++ b/tests/test_latentdistributiontest.py
@@ -55,8 +55,6 @@ class TestLatentDistributionTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             LatentDistributionTest(test="dcorr", n_bootstraps=0.5)
         with self.assertRaises(TypeError):
-            LatentDistributionTest(test="dcorr", n_components=0.5)
-        with self.assertRaises(TypeError):
             LatentDistributionTest(test="dcorr", workers=0.5)
 
     def test_n_bootstraps(self):
@@ -118,7 +116,7 @@ class TestLatentDistributionTest(unittest.TestCase):
             self.assertTrue(p_null > 0.05)
             self.assertTrue(p_alt <= 0.05)
 
-    def test_different_sizes(self):
+    def test_different_sizes_null(self):
         np.random.seed(314)
 
         A1 = er_np(100, 0.8)
@@ -138,9 +136,29 @@ class TestLatentDistributionTest(unittest.TestCase):
         p_corrected_1 = ldt_corrected_1.fit_predict(A1, A2)
         p_corrected_2 = ldt_corrected_2.fit_predict(A2, A1)
 
+        print(p_not_corrected, p_corrected_1, p_corrected_2)
         self.assertTrue(p_not_corrected <= 0.05)
         self.assertTrue(p_corrected_1 > 0.05)
         self.assertTrue(p_corrected_2 > 0.05)
+
+    def test_different_sizes_alternative(self):
+        np.random.seed(314)
+
+        A1 = er_np(100, 0.8)
+        A2 = er_np(1000, 0.7)
+
+        ldt_corrected_1 = LatentDistributionTest(
+            "hsic", "gaussian", n_components=2, n_bootstraps=100, size_correction=True
+        )
+        ldt_corrected_2 = LatentDistributionTest(
+            "hsic", "gaussian", n_components=2, n_bootstraps=100, size_correction=True
+        )
+
+        p_corrected_1 = ldt_corrected_1.fit_predict(A1, A2)
+        p_corrected_2 = ldt_corrected_2.fit_predict(A2, A1)
+
+        self.assertTrue(p_corrected_1 <= 0.05)
+        self.assertTrue(p_corrected_2 <= 0.05)
 
 
 if __name__ == "__main__":

--- a/tests/test_latentdistributiontest.py
+++ b/tests/test_latentdistributiontest.py
@@ -45,7 +45,9 @@ class TestLatentDistributionTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             LatentDistributionTest(test="dcorr", n_bootstraps=-100)
         with self.assertRaises(ValueError):
-            LatentDistributionTest(test="dcorr", workers=-1)
+            LatentDistributionTest(test="dcorr", workers=0)
+        with self.assertRaises(ValueError):
+            LatentDistributionTest(test="dcorr", workers=-2)
         with self.assertRaises(TypeError):
             LatentDistributionTest(test=0)
         with self.assertRaises(TypeError):
@@ -68,6 +70,7 @@ class TestLatentDistributionTest(unittest.TestCase):
         with pytest.warns(None) as record:
             for test in self.tests.keys():
                 ldt = LatentDistributionTest(test, self.tests[test])
+            ldt = LatentDistributionTest("hsic", "rbf")
         assert len(record) == 0
         # some invalid combinations of test and metric
         with pytest.warns(UserWarning):

--- a/tests/test_latentdistributiontest.py
+++ b/tests/test_latentdistributiontest.py
@@ -91,8 +91,9 @@ class TestLatentDistributionTest(unittest.TestCase):
         B = er_np(100, 0.3, directed=True)
 
         ldt = LatentDistributionTest("dcorr")
-        with self.assertRaises(NotImplementedError):
-            ldt.fit(A, B)
+        # with self.assertRaises(NotImplementedError):
+        # ldt.fit(A, B)
+        ldt.fit(A, B)
 
     def test_SBM_dcorr(self):
         for test in self.tests.keys():
@@ -136,12 +137,11 @@ class TestLatentDistributionTest(unittest.TestCase):
         p_corrected_1 = ldt_corrected_1.fit_predict(A1, A2)
         p_corrected_2 = ldt_corrected_2.fit_predict(A2, A1)
 
-        print(p_not_corrected, p_corrected_1, p_corrected_2)
         self.assertTrue(p_not_corrected <= 0.05)
         self.assertTrue(p_corrected_1 > 0.05)
         self.assertTrue(p_corrected_2 > 0.05)
 
-    def test_different_sizes_alternative(self):
+    def test_different_sizes_nul(self):
         np.random.seed(314)
 
         A1 = er_np(100, 0.8)

--- a/tests/test_latentdistributiontest.py
+++ b/tests/test_latentdistributiontest.py
@@ -44,10 +44,6 @@ class TestLatentDistributionTest(unittest.TestCase):
             LatentDistributionTest(test="dcorr", n_components=-100)
         with self.assertRaises(ValueError):
             LatentDistributionTest(test="dcorr", n_bootstraps=-100)
-        with self.assertRaises(ValueError):
-            LatentDistributionTest(test="dcorr", workers=0)
-        with self.assertRaises(ValueError):
-            LatentDistributionTest(test="dcorr", workers=-2)
         with self.assertRaises(TypeError):
             LatentDistributionTest(test=0)
         with self.assertRaises(TypeError):

--- a/tests/test_latentdistributiontest.py
+++ b/tests/test_latentdistributiontest.py
@@ -124,13 +124,13 @@ class TestLatentDistributionTest(unittest.TestCase):
         A2 = er_np(1000, 0.8)
 
         ldt_not_corrected = LatentDistributionTest(
-            "hsic", "gaussian", n_components=2, n_bootstraps=100, size_correction=False
+            "hsic", "gaussian", n_components=2, n_bootstraps=100, order_correction=False
         )
         ldt_corrected_1 = LatentDistributionTest(
-            "hsic", "gaussian", n_components=2, n_bootstraps=100, size_correction=True
+            "hsic", "gaussian", n_components=2, n_bootstraps=100, order_correction=True
         )
         ldt_corrected_2 = LatentDistributionTest(
-            "hsic", "gaussian", n_components=2, n_bootstraps=100, size_correction=True
+            "hsic", "gaussian", n_components=2, n_bootstraps=100, order_correction=True
         )
 
         p_not_corrected = ldt_not_corrected.fit_predict(A1, A2)
@@ -148,10 +148,10 @@ class TestLatentDistributionTest(unittest.TestCase):
         A2 = er_np(1000, 0.7)
 
         ldt_corrected_1 = LatentDistributionTest(
-            "hsic", "gaussian", n_components=2, n_bootstraps=100, size_correction=True
+            "hsic", "gaussian", n_components=2, n_bootstraps=100, order_correction=True
         )
         ldt_corrected_2 = LatentDistributionTest(
-            "hsic", "gaussian", n_components=2, n_bootstraps=100, size_correction=True
+            "hsic", "gaussian", n_components=2, n_bootstraps=100, order_correction=True
         )
 
         p_corrected_1 = ldt_corrected_1.fit_predict(A1, A2)

--- a/tests/test_latentdistributiontest.py
+++ b/tests/test_latentdistributiontest.py
@@ -52,12 +52,24 @@ class TestLatentDistributionTest(unittest.TestCase):
             LatentDistributionTest(test="dcorr", n_bootstraps=0.5)
         with self.assertRaises(TypeError):
             LatentDistributionTest(test="dcorr", workers=0.5)
+        with self.assertRaises(TypeError):
+            LatentDistributionTest(size_correction=0)
+        with self.assertRaises(TypeError):
+            LatentDistributionTest(pooled=0)
 
     def test_n_bootstraps(self):
         for test in self.tests.keys():
             ldt = LatentDistributionTest(test, self.tests[test], n_bootstraps=123)
             ldt.fit(self.A1, self.A2)
             self.assertEqual(ldt.null_distribution_.shape[0], 123)
+
+    def test_pooled(self):
+        np.random.seed(123)
+        A1 = er_np(20, 0.3)
+        A2 = er_np(100, 0.3)
+
+        ldt = LatentDistributionTest(pooled=True)
+        ldt.fit(self.A1, self.A2)
 
     def test_distances_and_kernels(self):
         # some valid combinations of test and metric

--- a/tests/test_latentdistributiontest.py
+++ b/tests/test_latentdistributiontest.py
@@ -89,11 +89,17 @@ class TestLatentDistributionTest(unittest.TestCase):
         np.random.seed(2)
         A = er_np(100, 0.3, directed=True)
         B = er_np(100, 0.3, directed=True)
+        C = er_np(100, 0.3, directed=False)
 
+        # two directed graphs is okay
         ldt = LatentDistributionTest("dcorr")
-        # with self.assertRaises(NotImplementedError):
-        # ldt.fit(A, B)
         ldt.fit(A, B)
+
+        # an undirected and a direced graph is not okay
+        with self.assertRaises(ValueError):
+            ldt.fit(A, C)
+        with self.assertRaises(ValueError):
+            ldt.fit(C, B)
 
     def test_SBM_dcorr(self):
         for test in self.tests.keys():

--- a/tests/test_latentdistributiontest.py
+++ b/tests/test_latentdistributiontest.py
@@ -130,13 +130,13 @@ class TestLatentDistributionTest(unittest.TestCase):
         A2 = er_np(1000, 0.8)
 
         ldt_not_corrected = LatentDistributionTest(
-            "hsic", "gaussian", n_components=2, n_bootstraps=100, order_correction=False
+            "hsic", "gaussian", n_components=2, n_bootstraps=100, size_correction=False
         )
         ldt_corrected_1 = LatentDistributionTest(
-            "hsic", "gaussian", n_components=2, n_bootstraps=100, order_correction=True
+            "hsic", "gaussian", n_components=2, n_bootstraps=100, size_correction=True
         )
         ldt_corrected_2 = LatentDistributionTest(
-            "hsic", "gaussian", n_components=2, n_bootstraps=100, order_correction=True
+            "hsic", "gaussian", n_components=2, n_bootstraps=100, size_correction=True
         )
 
         p_not_corrected = ldt_not_corrected.fit_predict(A1, A2)
@@ -154,10 +154,10 @@ class TestLatentDistributionTest(unittest.TestCase):
         A2 = er_np(1000, 0.7)
 
         ldt_corrected_1 = LatentDistributionTest(
-            "hsic", "gaussian", n_components=2, n_bootstraps=100, order_correction=True
+            "hsic", "gaussian", n_components=2, n_bootstraps=100, size_correction=True
         )
         ldt_corrected_2 = LatentDistributionTest(
-            "hsic", "gaussian", n_components=2, n_bootstraps=100, order_correction=True
+            "hsic", "gaussian", n_components=2, n_bootstraps=100, size_correction=True
         )
 
         p_corrected_1 = ldt_corrected_1.fit_predict(A1, A2)

--- a/tests/test_latentdistributiontest.py
+++ b/tests/test_latentdistributiontest.py
@@ -143,7 +143,7 @@ class TestLatentDistributionTest(unittest.TestCase):
         self.assertTrue(p_corrected_1 > 0.05)
         self.assertTrue(p_corrected_2 > 0.05)
 
-    def test_different_sizes_nul(self):
+    def test_different_sizes_null(self):
         np.random.seed(314)
 
         A1 = er_np(100, 0.8)

--- a/tests/test_latentdistributiontest.py
+++ b/tests/test_latentdistributiontest.py
@@ -138,7 +138,6 @@ class TestLatentDistributionTest(unittest.TestCase):
         p_corrected_1 = ldt_corrected_1.fit_predict(A1, A2)
         p_corrected_2 = ldt_corrected_2.fit_predict(A2, A1)
 
-        print(p_not_corrected, p_corrected_1, p_corrected_2)
         self.assertTrue(p_not_corrected <= 0.05)
         self.assertTrue(p_corrected_1 > 0.05)
         self.assertTrue(p_corrected_2 > 0.05)

--- a/tests/test_latentdistributiontest.py
+++ b/tests/test_latentdistributiontest.py
@@ -86,7 +86,7 @@ class TestLatentDistributionTest(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             ldt.fit(A, B)
 
-    def test_SBM_euclidean(self):
+    def test_SBM_dcorr(self):
         np.random.seed(12345678)
         B1 = np.array([[0.5, 0.2], [0.2, 0.5]])
 
@@ -96,19 +96,18 @@ class TestLatentDistributionTest(unittest.TestCase):
         A2 = sbm(2 * [b_size], B1)
         A3 = sbm(2 * [b_size], B2)
 
-        for test in self.tests:
-            ldt_null = LatentDistributionTest(
-                test, "euclidean", n_components=2, n_bootstraps=50
-            )
-            ldt_alt = LatentDistributionTest(
-                test, "euclidean", n_components=2, n_bootstraps=50
-            )
-            p_null = ldt_null.fit_predict(A1, A2)
-            p_alt = ldt_alt.fit_predict(A1, A3)
-            self.assertTrue(p_null > 0.05)
-            self.assertTrue(p_alt <= 0.05)
+        ldt_null = LatentDistributionTest(
+            "dcorr", "euclidean", n_components=2, n_bootstraps=100
+        )
+        ldt_alt = LatentDistributionTest(
+            "dcorr", "euclidean", n_components=2, n_bootstraps=100
+        )
+        p_null = ldt_null.fit_predict(A1, A2)
+        p_alt = ldt_alt.fit_predict(A1, A3)
+        self.assertTrue(p_null > 0.05)
+        self.assertTrue(p_alt <= 0.05)
 
-    def test_SBM_gaussian(self):
+    def test_SBM_hsic(self):
         np.random.seed(12345678)
         B1 = np.array([[0.5, 0.2], [0.2, 0.5]])
 
@@ -118,17 +117,41 @@ class TestLatentDistributionTest(unittest.TestCase):
         A2 = sbm(2 * [b_size], B1)
         A3 = sbm(2 * [b_size], B2)
 
-        for test in self.tests:
-            ldt_null = LatentDistributionTest(
-                test, "gaussian", n_components=2, n_bootstraps=50
-            )
-            ldt_alt = LatentDistributionTest(
-                test, "gaussian", n_components=2, n_bootstraps=50
-            )
-            p_null = ldt_null.fit_predict(A1, A2)
-            p_alt = ldt_alt.fit_predict(A1, A3)
-            self.assertTrue(p_null > 0.05)
-            self.assertTrue(p_alt <= 0.05)
+        ldt_null = LatentDistributionTest(
+            "hsic", "gaussian", n_components=2, n_bootstraps=100
+        )
+        ldt_alt = LatentDistributionTest(
+            "hsic", "gaussian", n_components=2, n_bootstraps=100
+        )
+        p_null = ldt_null.fit_predict(A1, A2)
+        p_alt = ldt_alt.fit_predict(A1, A3)
+        self.assertTrue(p_null > 0.05)
+        self.assertTrue(p_alt <= 0.05)
+
+    def test_different_sizes(self):
+        np.random.seed(314)
+
+        A1 = er_np(100, 0.8)
+        A2 = er_np(1000, 0.8)
+
+        ldt_not_corrected = LatentDistributionTest(
+        "hsic", "gaussian", n_components=2, n_bootstraps=100, size_correction=False
+        )
+        ldt_corrected_1 = LatentDistributionTest(
+        "hsic", "gaussian", n_components=2, n_bootstraps=100, size_correction=True
+        )
+        ldt_corrected_2 = LatentDistributionTest(
+        "hsic", "gaussian", n_components=2, n_bootstraps=100, size_correction=True
+        )
+
+        p_not_corrected = ldt_not_corrected.fit_predict(A1, A2)
+        p_corrected_1 = ldt_corrected_1.fit_predict(A1, A2)
+        p_corrected_2 = ldt_corrected_2.fit_predict(A2, A1)
+
+        print(p_not_corrected, p_corrected_1, p_corrected_2)
+        self.assertTrue(p_not_corrected <= 0.05)
+        self.assertTrue(p_corrected_1 > 0.05)
+        self.assertTrue(p_corrected_2 > 0.05)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### Reference Issues/PRs
- Fixes #222 
- Fixes #358  
- Fixes #363 
- Fixes #370  (the 0 permutations part; for change in api see #375)

#### What does this implement/fix? Explain your changes.
For #222:
- introduced the sampling from the asymptotic distribution of the ase correction
- added corresponding unit tests

For #358:
- No longer raises an exception with directed inputs
- Added corresponding tests

For #363:
- added the capability to use sklearn kernels (for hsic test, which is same as mmd) 
- raising warnings when distance used with hsic or kernel used with hsic
- added corresponding unit tests

For #370:
- No longer raises an exception with 0 bootstraps
- fit_predict left unchanged (returns a nan if used with 0 bootstraps)

Miscellaneous:
- removed gaussian medial kernel implementation and instead importing it from hyppo
  - avoid code duplication 
  - that version is parallelizable
- the default changed from "dcorr" + "euclidean" to "hsic" + "gaussian". reasoning behind the change:
  1. in theory, dcorr and hsic are almost the same, except that one uses distances and the other uses kernels (they are in fact, equivalent for some choices of distances and kernels, as per distances and kernels EE paper). in practice "dcorr" + "euclidean" and "hsic"+"gaussian" either perform very similarly, or "hsic" has an advantage (see: https://mgc.neurodata.io/tutorials/independence/indep_power.html ) .
  2. Minh's nonpar paper, which proves the convergence uses Gretton's MMD (which is same as "use k-sample transform + hsic"), rather than Energy (which  is same as "use k-sample transform + dcorr"). i wouldn't be surprised if it is possible to prove a similar thing for Energy as well, but no one has yet.
  3. the test that we used to have before adding hyppo backend (MMD) is the same as "hsic" + "gaussian". obviously because of implementation differences, results of old sims won't be reproduced exactly, even when seeded, but this is the closest possible choice to be "backward-compatible"
  4. all my simulations for the size correction paper were performed with MMD. in theory, they should transfer to, say, dcorr and maybe other tests, but i am most confident in this specific choice.
- added an option to use workers=-1 to specify all possible threads (consistent with hyppo and sklearn)
- passing workers to sklearn's distances and kernels

#### Any other comments?
Does not address #177 