### PR TITLE
save metric kwarg as attribute

### DIFF
--- a/graspy/inference/latent_distribution_test.py
+++ b/graspy/inference/latent_distribution_test.py
@@ -228,6 +228,7 @@ class LatentDistributionTest(BaseInference):
         self.workers = workers
         self.size_correction = size_correction
         self.pooled = pooled
+        self.metric = metric
 
     def _embed(self, A1, A2):
         if self.n_components is None:


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Metric kwarg should be stored as an attribute
