### PR TITLE
Set maximum MPL version, reduce LDT tutorial runtime

### DIFF
--- a/docs/tutorials/inference/latent_distribution_test.ipynb
+++ b/docs/tutorials/inference/latent_distribution_test.ipynb
@@ -107,7 +107,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ldt_dcorr = LatentDistributionTest(\"dcorr\", metric=\"euclidean\", n_bootstraps=200)\n",
+    "ldt_dcorr = LatentDistributionTest(\"dcorr\", metric=\"euclidean\", n_bootstraps=100)\n",
     "ldt_dcorr.fit(A1, A2)"
    ]
   },
@@ -117,7 +117,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ldt_mgc = LatentDistributionTest(\"mgc\", metric=\"euclidean\", n_bootstraps=200)\n",
+    "ldt_mgc = LatentDistributionTest(\"mgc\", metric=\"euclidean\", n_bootstraps=100)\n",
     "ldt_mgc.fit(A1, A2)"
    ]
   },
@@ -192,7 +192,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ldt_dcorr = LatentDistributionTest(\"dcorr\", metric=\"euclidean\", n_bootstraps=200)\n",
+    "ldt_dcorr = LatentDistributionTest(\"dcorr\", metric=\"euclidean\", n_bootstraps=100)\n",
     "ldt_dcorr.fit(A1, A3)"
    ]
   },
@@ -202,7 +202,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ldt_mgc = LatentDistributionTest(\"mgc\", metric=\"euclidean\", n_bootstraps=200)\n",
+    "ldt_mgc = LatentDistributionTest(\"mgc\", metric=\"euclidean\", n_bootstraps=100)\n",
     "ldt_mgc.fit(A1, A3)"
    ]
   },
@@ -230,13 +230,6 @@
     "ax[1].set_title(\"MGC: P-value = {}\".format(ldt_mgc.p_value_), fontsize=20)\n",
     "plt.show();"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ numpy>=1.8.1
 scikit-learn>=0.19.1
 scipy>=1.1.0
 seaborn>=0.9.0
-matplotlib>=3.0.0
+matplotlib>=3.0.0,<=3.3.0
 hyppo>=0.1.2
 


### PR DESCRIPTION
### Issues
seaborn https://github.com/mwaskom/seaborn/issues/2194 

### What does this implement/fix? Explain your changes.
- Fix bug in master due to new matplotlib 3.1.1 
- Reduce number of bootstraps in `LatentDistributionTest` tutorial to make it run faster