### PR TITLE
Remove ari return value from AutoGMM.fit_predict

### DIFF
--- a/graspy/cluster/base.py
+++ b/graspy/cluster/base.py
@@ -61,19 +61,12 @@ class BaseCluster(ABC, BaseEstimator, ClusterMixin):
         -------
         labels : array, shape (n_samples,)
             Component labels.
-
-        ari : float
-            Adjusted Rand index. Only returned if y is given.
         """
         # Check if fit is already called
         check_is_fitted(self, ["model_"], all_or_any=all)
         labels = self.model_.predict(X)
 
-        if y is None:
-            return labels
-        else:
-            ari = adjusted_rand_score(y, labels)
-            return labels, ari
+        return labels
 
     def fit_predict(self, X, y=None):  # pragma: no cover
         """
@@ -93,15 +86,8 @@ class BaseCluster(ABC, BaseEstimator, ClusterMixin):
         -------
         labels : array, shape (n_samples,)
             Component labels.
-
-        ari : float
-            Adjusted Rand index. Only returned if y is given.
         """
         self.fit(X, y)
 
-        if y is None:
-            labels = self.predict(X, y)
-            return labels
-        else:
-            labels, ari = self.predict(X, y)
-            return labels, ari
+        labels = self.predict(X, y)
+        return labels


### PR DESCRIPTION
#### Reference Issues/PRs
Fixes #369 



#### What does this implement/fix?
Removes ari return value from `fit_predict` and `predict` functions in base for cluster class
